### PR TITLE
Some cleanup - mostly to take a look around the Remarkable code

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,4 +2,6 @@ node_modules
 .embeddable
 .embeddable-build
 .embeddable-dev-build
+.embeddable-dev-tmp
 embeddable-entry-point.jsx
+.DS_Store

--- a/.prettierrc
+++ b/.prettierrc
@@ -1,4 +1,9 @@
 {
+  "bracketSpacing": true,
+  "semi": true,
+  "singleQuote": true,
+  "tabWidth": 2,
+  "trailingComma": "all",
   "useTabs": true,
-  "singleQuote": true
+  "printWidth": 100
 }

--- a/embeddable.config.ts
+++ b/embeddable.config.ts
@@ -2,24 +2,24 @@ import { defineConfig } from '@embeddable.com/sdk-core';
 import react from '@embeddable.com/sdk-react';
 
 export default defineConfig({
-  plugins: [react],
+	plugins: [react],
 
-  // 
-  // Uncomment for US deployments
-  //
-  // region: 'US'
-  
-  //
-  // Uncomment for EU deployments
-  //
-  region: 'EU'
+	//
+	// Uncomment for US deployments
+	//
+	// region: 'US'
 
-  //
-  // For internal use only
-  //
-  // previewBaseUrl: 'https://app.dev.embeddable.com',
-  // pushBaseUrl: 'https://api.dev.embeddable.com',
-  // audienceUrl: 'https://api.dev.embeddable.com/',
-  // authDomain: 'embeddable-dev.eu.auth0.com',
-  // authClientId: 'xOKco5ztFCpWn54bJbFkAcT8mV4LLcpG',
+	//
+	// Uncomment for EU deployments
+	//
+	region: 'EU',
+
+	//
+	// For internal use only
+	//
+	// previewBaseUrl: 'https://app.dev.embeddable.com',
+	// pushBaseUrl: 'https://api.dev.embeddable.com',
+	// audienceUrl: 'https://api.dev.embeddable.com/',
+	// authDomain: 'embeddable-dev.eu.auth0.com',
+	// authClientId: 'xOKco5ztFCpWn54bJbFkAcT8mV4LLcpG',
 });

--- a/embeddable.theme.ts
+++ b/embeddable.theme.ts
@@ -2,66 +2,65 @@
 // 	- Contains a themeProvider function.
 // 	- themeProvider takes clientContext and parentTheme as arguments.
 // 	- It’s first called by the parent component library (e.g. Remarkable UI) and then the Boiler Plate library.
-// 	- In this library it simply returns the default theme. 
-//  - In the Boiler Plate library, it merges the client theme with the parent theme and returns that. 
+// 	- In this library it simply returns the default theme.
+//  - In the Boiler Plate library, it merges the client theme with the parent theme and returns that.
 //  - The merged theme is returned at the component level by the useTheme() react hook.
 
-import { mergician } from 'mergician';
+import { DataResponse, defineTheme } from '@embeddable.com/core';
 import remarkableTheme from './src/themes/remarkableTheme/remarkableTheme';
 import { DropdownItem } from './src/remarkable-ui/shared/BaseDropdown';
-import { DataResponse } from '@embeddable.com/core';
 
-const themeProvider = (clientContext: any, parentTheme:any): any => {
+const themeProvider = (clientContext: any, parentTheme: any): any => {
+	//Test. TODO: Remove this later.
+	const theme = clientContext.theme;
 
-    //Test. TODO: Remove this later. 
-    const theme = clientContext.theme;
-    
-    //test overrides
-    const darkModeVariables = {
-        '--background-default': '#111',
-        '--background-inverted': '#fafafa',
-        '--background-neutral': '#222',
-        '--foreground-default': '#fff',
-        '--foreground-inverted': '#111',
-        '--foreground-muted': '#fff',
-        '--border-radius-default': '0px',
-        '--background-light': '#333',
-        '--icn-color': '#fafafa',
-        '--background-subtle': '#444'
-    }
+	//test overrides
+	const darkModeVariables = {
+		'--background-default': '#111',
+		'--background-inverted': '#fafafa',
+		'--background-neutral': '#222',
+		'--foreground-default': '#fff',
+		'--foreground-inverted': '#111',
+		'--foreground-muted': '#fff',
+		'--border-radius-default': '0px',
+		'--background-light': '#333',
+		'--icn-color': '#fafafa',
+		'--background-subtle': '#444',
+	};
 
-    //test custom format function
-    const customFormatFunction = (value:any) => {
-        return value + "wooop!"
-    }
+	//test custom format function
+	const customFormatFunction = (value: any) => {
+		return value + 'wooop!';
+	};
 
-    //test custom number function
-    const customNumberFormatFunction = (value:any) => {
-        return value + "nuuumber!"
-    }
+	//test custom number function
+	const customNumberFormatFunction = (value: any) => {
+		return value + 'nuuumber!';
+	};
 
-    const customExportOptions: DropdownItem[] = [
-        {
-            id: "testOption",
-            label: "Test Option",
-            onClick: (data: DataResponse["data"]) => { alert("test option!") }
-        }
-    ]
+	const customExportOptions: DropdownItem[] = [
+		{
+			id: 'testOption',
+			label: 'Test Option',
+			onClick: (data: DataResponse['data']) => {
+				alert('test option!');
+			},
+		},
+	];
 
-    const testTheme = {
-        styles: {
-            ...(theme === 'dark' ? darkModeVariables : {}),
-        },
-        // charts: {
-        //     legendPosition: 'right'
-        // },
-        //customFormatFunction: customFormatFunction,
-        // customNumberFormatFunction: customNumberFormatFunction,
-        //customExportOptions: customExportOptions,
-        
-    }
+	const testTheme = {
+		styles: {
+			...(theme === 'dark' ? darkModeVariables : {}),
+		},
+		// charts: {
+		//     legendPosition: 'right'
+		// },
+		//customFormatFunction: customFormatFunction,
+		// customNumberFormatFunction: customNumberFormatFunction,
+		//customExportOptions: customExportOptions,
+	};
 
-    return mergician(remarkableTheme, testTheme);
+	return defineTheme(remarkableTheme, testTheme);
 };
 
 export default themeProvider;

--- a/src/remarkable-ui/charts/Pie/DonutChart/DonutChart.emb.ts
+++ b/src/remarkable-ui/charts/Pie/DonutChart/DonutChart.emb.ts
@@ -1,94 +1,101 @@
 // Embeddable Libraries
-import { Value, loadData, DataResponse, Dimension, Measure } from '@embeddable.com/core';
+import { DataResponse, Dimension, Measure, Value, loadData } from '@embeddable.com/core';
 import { EmbeddedComponentMeta, Inputs, defineComponent } from '@embeddable.com/react';
 
 // Local Libraries
-import { title, description, showLegend, showToolTips, showValueLabels, maxLegendItems } from '../../../constants/commonChartInputs';
+import {
+	description,
+	maxLegendItems,
+	showLegend,
+	showToolTips,
+	showValueLabels,
+	title,
+} from '../../../constants/commonChartInputs';
 import DonutChart from './index';
 
 export type DonutChartProps = {
-  description?: string;
-  dimension: Dimension;
-  maxLegendItems?: number;
-  measure: Measure;
-  results: DataResponse;
-  showLegend?: boolean;
-  showTooltips?: boolean;
-  showValueLabels?: boolean;
-  title?: string;
-  onSegmentClick: (args: { dimensionValue: string | null; }) => void;
-}
+	description?: string;
+	dimension: Dimension;
+	maxLegendItems?: number;
+	measure: Measure;
+	onSegmentClick: (args: { dimensionValue: string | null }) => void;
+	results: DataResponse;
+	showLegend?: boolean;
+	showTooltips?: boolean;
+	showValueLabels?: boolean;
+	title?: string;
+};
 
 export const meta = {
-  name: 'DonutChart',
-  label: 'Donut Chart',
-  category: 'Pie Charts',
-  inputs: [
-    {
-        name: 'dataset',
-        type: 'dataset',
-        label: 'Dataset',
-        required: true,
-        category: 'Chart Data'
-    },
-    {
-        name: 'measure',
-        type: 'measure',
-        label: 'Measure',
-        config: {
-            dataset: 'dataset', // restricts measure options to the selected dataset
-        },
-        required: true,
-        category: 'Chart Data'
-    },
-    {
-        name: 'dimension',
-        type: 'dimension',
-        label: 'Dimension',
-        config: {
-            dataset: 'dataset',
-        },
-        required: true,
-        category: 'Chart Data'
-    },
-    {...title},
-    {...description},  
-    {...showLegend},
-    {...maxLegendItems},  
-    {...showToolTips}, 
-    {...showValueLabels}
-  ],
-  events: [
-    {
-      name: 'onSegmentClick',
-      label: 'A segment is clicked',
-      properties: [
-        {
-          name: 'dimensionValue',
-          label: 'Clicked Dimension',
-          type: 'string',
-        }
-      ],
-    },
-  ],
+	name: 'DonutChart',
+	label: 'Donut Chart',
+	category: 'Pie Charts',
+	inputs: [
+		{
+			name: 'dataset',
+			type: 'dataset',
+			label: 'Dataset',
+			required: true,
+			category: 'Chart Data',
+		},
+		{
+			name: 'measure',
+			type: 'measure',
+			label: 'Measure',
+			config: {
+				dataset: 'dataset', // restricts measure options to the selected dataset
+			},
+			required: true,
+			category: 'Chart Data',
+		},
+		{
+			name: 'dimension',
+			type: 'dimension',
+			label: 'Dimension',
+			config: {
+				dataset: 'dataset',
+			},
+			required: true,
+			category: 'Chart Data',
+		},
+		{ ...title },
+		{ ...description },
+		{ ...showLegend },
+		{ ...maxLegendItems },
+		{ ...showToolTips },
+		{ ...showValueLabels },
+	],
+	events: [
+		{
+			name: 'onSegmentClick',
+			label: 'A segment is clicked',
+			properties: [
+				{
+					name: 'dimensionValue',
+					label: 'Clicked Dimension',
+					type: 'string',
+				},
+			],
+		},
+	],
 } as const satisfies EmbeddedComponentMeta;
 
 export default defineComponent(DonutChart, meta, {
-  props: (inputs: Inputs<typeof meta>) => {
-    return {
-        ...inputs,
-        results: loadData({
-            from: inputs.dataset,
-            measures: [inputs.measure], 
-            dimensions: [inputs.dimension], 
-        })
-    };
-  },
-  events: {
-    onSegmentClick: (value) => {
-      return {
-        dimensionValue: value.dimensionValue || Value.noFilter(),
-      };
-    },
-  },
+	props: (inputs: Inputs<typeof meta>) => {
+		return {
+			...inputs,
+			results: loadData({
+				from: inputs.dataset,
+				measures: [inputs.measure],
+				dimensions: [inputs.dimension],
+			}),
+		};
+	},
+	events: {
+		onSegmentClick: (value) => {
+			return {
+				dimensionValue: value.dimensionValue || Value.noFilter(),
+			};
+		},
+	},
 });

--- a/src/remarkable-ui/charts/Pie/DonutChart/index.tsx
+++ b/src/remarkable-ui/charts/Pie/DonutChart/index.tsx
@@ -1,51 +1,43 @@
-// Third Party Libraries
-import React from 'react';
-import { ChartOptions } from 'chart.js';
-
-// Embeddable Libraries
-import { DataResponse, Dimension, Measure } from '@embeddable.com/core';
-
 // Local Libraries
 import Card from '../../../shared/Card';
 import BasePieChart from '../../../shared/BasePieChart';
 import { DonutChartProps } from './DonutChart.emb';
 
 export default ({
-    description,
-    dimension,
-    maxLegendItems,
-    measure,
-    onSegmentClick,
-    results,
-    showLegend,
-    showTooltips,
-    showValueLabels,
-    title,
+	description,
+	dimension,
+	maxLegendItems,
+	measure,
+	onSegmentClick,
+	results,
+	showLegend,
+	showTooltips,
+	showValueLabels,
+	title,
 }: DonutChartProps) => {
+	const chartOptionsOverrides = {
+		cutout: '60%',
+	};
 
-    const chartOptionsOverrides= {
-        cutout: '60%',
-    }
-
-    return (
-        <Card
-            data={results.data}            
-            description={description}
-            errorMessage={results.error}
-            isLoading={results.isLoading}
-            title={title}
-        >
-            <BasePieChart 
-                chartOptionsOverrides={chartOptionsOverrides}
-                dimension={dimension}
-                measure={measure}
-                onSegmentClick={onSegmentClick}
-                results={results}
-                showDataLabels={showValueLabels ? 'auto' : false}
-                showLegend={showLegend}
-                showTooltips={showTooltips}
-                maxLegendItems={maxLegendItems}
-            />        
-        </Card>
-    );
+	return (
+		<Card
+			data={results.data}
+			description={description}
+			errorMessage={results.error}
+			isLoading={results.isLoading}
+			title={title}
+		>
+			<BasePieChart
+				chartOptionsOverrides={chartOptionsOverrides}
+				dimension={dimension}
+				maxLegendItems={maxLegendItems}
+				measure={measure}
+				onSegmentClick={onSegmentClick}
+				results={results}
+				showDataLabels={showValueLabels ? 'auto' : false}
+				showLegend={showLegend}
+				showTooltips={showTooltips}
+			/>
+		</Card>
+	);
 };

--- a/src/remarkable-ui/charts/Pie/DonutChartWithLabel/DonutChartWithLabel.emb.ts
+++ b/src/remarkable-ui/charts/Pie/DonutChartWithLabel/DonutChartWithLabel.emb.ts
@@ -1,110 +1,126 @@
 // Embeddable Libraries
-import { loadData, DataResponse, Dimension, Measure, Value } from '@embeddable.com/core';
-import { EmbeddedComponentMeta, Inputs, defineComponent } from '@embeddable.com/react';
+import { DataResponse, Dimension, Measure, Value, loadData } from '@embeddable.com/core';
+import { defineComponent, EmbeddedComponentMeta, Inputs } from '@embeddable.com/react';
 
 // Local Libraries
-import { title, description, showLegend, showToolTips, showValueLabels, maxLegendItems } from '../../../constants/commonChartInputs';
+import {
+	description,
+	maxLegendItems,
+	showLegend,
+	showToolTips,
+	showValueLabels,
+	title,
+} from '../../../constants/commonChartInputs';
 import DonutChartWithLabel from './index';
 
 export type DonutChartWithLabelProps = {
-    description?: string;
-    dimension: Dimension;
-    innerLabelMeasure: Measure,
-    maxLegendItems?: number;
-    measure: Measure;
-    onSegmentClick: (args: { dimensionValue: string | null; }) => void;
-    results: DataResponse;
-    resultsInnerLabel: DataResponse;
-    showLegend?: boolean;
-    showTooltips?: boolean;
-    showValueLabels?: boolean;
-    title?: string;
-}
+	description?: string;
+	dimension: Dimension;
+	innerLabelMeasure: Measure;
+	innerLabelText?: string;
+	maxLegendItems?: number;
+	measure: Measure;
+	onSegmentClick: (args: { dimensionValue: string | null }) => void;
+	results: DataResponse;
+	resultsInnerLabel: DataResponse;
+	showLegend?: boolean;
+	showTooltips?: boolean;
+	showValueLabels?: boolean;
+	title?: string;
+};
 
 export const meta = {
-    name: 'DonutChartWithLabel',
-    label: 'Donut Chart With Label',
-    category: 'Pie Charts',
-    inputs: [
-        {
-            name: 'dataset',
-            type: 'dataset' as 'dataset',
-            label: 'Dataset',
-            required: true,
-            category: 'Chart Data'
-        },
-        {
-            name: 'measure',
-            type: 'measure' as 'measure',
-            label: 'Measure',
-            config: {
-                dataset: 'dataset', // restricts measure options to the selected dataset
-            },
-            required: true,
-            category: 'Chart Data'
-        },
-        {
-            name: 'dimension',
-            type: 'dimension' as 'dimension',
-            label: 'Dimension',
-            config: {
-                dataset: 'dataset',
-            },
-            required: true,
-            category: 'Chart Data'
-        },
-        {
-            name: 'innerLabelMeasure',
-            type: 'measure',
-            label: 'Inner Label Measure',
-            config: {
-                dataset: 'dataset',
-            },
-            required: true,
-            category: 'Chart Data'
-        },
-        {...title},
-        {...description},
-        {...showLegend},
-        {...maxLegendItems}, 
-        {...showToolTips},
-        {...showValueLabels},
-    ],
-    events: [
-        {
-            name: 'onSegmentClick',
-            label: 'A segment is clicked',
-            properties: [
-            {
-                name: 'dimensionValue',
-                label: 'Clicked Dimension',
-                type: 'string',
-            }
-            ],
-        },
-    ],
+	name: 'DonutChartWithLabel',
+	label: 'Donut Chart With Label',
+	category: 'Pie Charts',
+	inputs: [
+		{
+			name: 'dataset',
+			type: 'dataset' as 'dataset',
+			label: 'Dataset',
+			required: true,
+			category: 'Chart Data',
+		},
+		{
+			name: 'measure',
+			type: 'measure' as 'measure',
+			label: 'Measure',
+			config: {
+				dataset: 'dataset', // restricts measure options to the selected dataset
+			},
+			required: true,
+			category: 'Chart Data',
+		},
+		{
+			name: 'dimension',
+			type: 'dimension' as 'dimension',
+			label: 'Dimension',
+			config: {
+				dataset: 'dataset',
+			},
+			required: true,
+			category: 'Chart Data',
+		},
+		{
+			name: 'innerLabelMeasure',
+			type: 'measure',
+			label: 'Inner Label Measure',
+			config: {
+				dataset: 'dataset',
+			},
+			required: true,
+			category: 'Chart Data',
+		},
+		{
+			name: 'innerLabelText',
+			type: 'string',
+			label: 'Inner Label Text',
+			description: 'Text to display inside the donut chart',
+			required: false,
+			category: 'Chart Data',
+		},
+		{ ...title },
+		{ ...description },
+		{ ...showLegend },
+		{ ...maxLegendItems },
+		{ ...showToolTips },
+		{ ...showValueLabels },
+	],
+	events: [
+		{
+			name: 'onSegmentClick',
+			label: 'A segment is clicked',
+			properties: [
+				{
+					name: 'dimensionValue',
+					label: 'Clicked Dimension',
+					type: 'string',
+				},
+			],
+		},
+	],
 } as const satisfies EmbeddedComponentMeta;
 
 export default defineComponent(DonutChartWithLabel, meta, {
-    props: (inputs: Inputs<typeof meta>) => {
-        return {
-            ...inputs,
-            results: loadData({
-                from: inputs.dataset,
-                measures: [inputs.measure], 
-                dimensions: [inputs.dimension], 
-            }),
-            resultsInnerLabel: loadData({
-                from: inputs.dataset,
-                measures: [inputs.innerLabelMeasure]
-            })
-        };
-    },
-    events: {
-        onSegmentClick: (value) => {
-          return {
-            dimensionValue: value.dimensionValue || Value.noFilter(),
-          };
-        },
-    },
+	props: (inputs: Inputs<typeof meta>) => {
+		return {
+			...inputs,
+			results: loadData({
+				from: inputs.dataset,
+				measures: [inputs.measure],
+				dimensions: [inputs.dimension],
+			}),
+			resultsInnerLabel: loadData({
+				from: inputs.dataset,
+				measures: [inputs.innerLabelMeasure],
+			}),
+		};
+	},
+	events: {
+		onSegmentClick: (value) => {
+			return {
+				dimensionValue: value.dimensionValue || Value.noFilter(),
+			};
+		},
+	},
 });

--- a/src/remarkable-ui/charts/Pie/DonutChartWithLabel/index.tsx
+++ b/src/remarkable-ui/charts/Pie/DonutChartWithLabel/index.tsx
@@ -43,7 +43,12 @@ export default ({
 								typeHint: 'number',
 								theme: theme,
 							}),
-							formatValue(innerLabelText || '', { typeHint: 'string', theme: theme }),
+							// only show the second line if it exists (we use array spreading to avoid an empty string)
+							[
+								...(innerLabelText
+									? formatValue(innerLabelText || '', { typeHint: 'string', theme: theme })
+									: []),
+							],
 						], //one element per line
 						font: [
 							{

--- a/src/remarkable-ui/charts/Pie/DonutChartWithLabel/index.tsx
+++ b/src/remarkable-ui/charts/Pie/DonutChartWithLabel/index.tsx
@@ -1,22 +1,22 @@
 // Third Party Libraries
-import React from "react";
-import { ChartOptions } from "chart.js";
+import { ChartOptions } from 'chart.js';
 
 // Embeddable Libraries
-import { useTheme } from "@embeddable.com/react";
+import { useTheme } from '@embeddable.com/react';
 
 // Local Libraries
-import Card from "../../../shared/Card";
-import BasePieChart from "../../../shared/BasePieChart";
-import { DonutChartWithLabelProps } from "./DonutChartWithLabel.emb";
-import { getStyle } from "../../../utils/cssUtils";
-import { formatValue } from "../../../utils/formatUtils";
-import { Theme } from "../../../../themes/remarkableTheme/theme";
+import BasePieChart from '../../../shared/BasePieChart';
+import Card from '../../../shared/Card';
+import { DonutChartWithLabelProps } from './DonutChartWithLabel.emb';
+import { Theme } from '../../../../themes/remarkableTheme/theme';
+import { formatValue } from '../../../utils/formatUtils';
+import { getStyle } from '../../../utils/cssUtils';
 
 export default ({
 	description,
 	dimension,
 	innerLabelMeasure,
+	innerLabelText,
 	maxLegendItems,
 	measure,
 	onSegmentClick,
@@ -29,38 +29,37 @@ export default ({
 }: DonutChartWithLabelProps) => {
 	const theme = useTheme() as Theme;
 
-	const innerLabelValue =
-		resultsInnerLabel?.data?.[0]?.[innerLabelMeasure.name] || "...";
+	const innerLabelValue = resultsInnerLabel?.data?.[0]?.[innerLabelMeasure.name] || '...';
 
-	const chartOptionsOverrides: Partial<ChartOptions<"pie">> = {
-		cutout: "60%",
+	const chartOptionsOverrides: Partial<ChartOptions<'pie'>> = {
+		cutout: '60%',
 		plugins: {
 			annotation: {
 				annotations: {
 					innerlabel: {
-						type: "doughnutLabel",
+						type: 'doughnutLabel',
 						content: () => [
 							formatValue(innerLabelValue, {
-								typeHint: "number",
+								typeHint: 'number',
 								theme: theme,
 							}),
-							formatValue("Some Label", { typeHint: "string", theme: theme }), //TODO: replace "Some Label" with data (or an additional input associated with the InnerLabelValue Measure)
+							formatValue(innerLabelText || '', { typeHint: 'string', theme: theme }),
 						], //one element per line
 						font: [
 							{
-								family: getStyle("--donut-number-family"),
-								size: getStyle("--donut-number-size"),
-								weight: getStyle("--donut-number-weight"),
+								family: getStyle('--donut-number-family'),
+								size: getStyle('--donut-number-size'),
+								weight: getStyle('--donut-number-weight'),
 							},
 							{
-								family: getStyle("--donut-label-family"),
-								size: getStyle("--donut-label-size"),
-								weight: getStyle("--donut-label-weight"),
+								family: getStyle('--donut-label-family'),
+								size: getStyle('--donut-label-size'),
+								weight: getStyle('--donut-label-weight'),
 							},
 						],
 						color: [
-							getStyle("--donut-number-color") as string,
-							getStyle("--donut-label-color") as string,
+							getStyle('--donut-number-color') as string,
+							getStyle('--donut-label-color') as string,
 						],
 					},
 				} as any,
@@ -81,13 +80,13 @@ export default ({
 			<BasePieChart
 				chartOptionsOverrides={chartOptionsOverrides}
 				dimension={dimension}
+				maxLegendItems={maxLegendItems}
 				measure={measure}
 				onSegmentClick={onSegmentClick}
 				results={results}
-				showDataLabels={showValueLabels ? "auto" : false}
+				showDataLabels={showValueLabels ? 'auto' : false}
 				showLegend={showLegend}
 				showTooltips={showTooltips}
-				maxLegendItems={maxLegendItems}
 			/>
 		</Card>
 	);

--- a/src/remarkable-ui/charts/Pie/DonutChartWithLabel/index.tsx
+++ b/src/remarkable-ui/charts/Pie/DonutChartWithLabel/index.tsx
@@ -43,12 +43,9 @@ export default ({
 								typeHint: 'number',
 								theme: theme,
 							}),
-							// only show the second line if it exists (we use array spreading to avoid an empty string)
-							[
-								...(innerLabelText
-									? formatValue(innerLabelText || '', { typeHint: 'string', theme: theme })
-									: []),
-							],
+							innerLabelText
+								? formatValue(innerLabelText || '', { typeHint: 'string', theme: theme })
+								: '',
 						], //one element per line
 						font: [
 							{

--- a/src/remarkable-ui/charts/Pie/PieChart/PieChart.emb.ts
+++ b/src/remarkable-ui/charts/Pie/PieChart/PieChart.emb.ts
@@ -1,94 +1,101 @@
 // Embeddable Libraries
-import { loadData, DataResponse, Dimension, Measure, Value } from '@embeddable.com/core';
-import { EmbeddedComponentMeta, Inputs, defineComponent } from '@embeddable.com/react';
+import { DataResponse, Dimension, Measure, Value, loadData } from '@embeddable.com/core';
+import { defineComponent, EmbeddedComponentMeta, Inputs } from '@embeddable.com/react';
 
 // Local Libraries
-import { title, description, showLegend, showToolTips, showValueLabels, maxLegendItems } from '../../../constants/commonChartInputs';
+import {
+	description,
+	maxLegendItems,
+	showLegend,
+	showToolTips,
+	showValueLabels,
+	title,
+} from '../../../constants/commonChartInputs';
 import PieChart from './index';
 
 export type PieChartProps = {
-  description?: string;
-  dimension: Dimension;
-  maxLegendItems?: number;
-  measure: Measure;
-  onSegmentClick: (args: { dimensionValue: string | null; }) => void;
-  results: DataResponse;
-  showLegend?: boolean;
-  showTooltips?: boolean;
-  showValueLabels?: boolean;
-  title?: string;
-}
+	description?: string;
+	dimension: Dimension;
+	maxLegendItems?: number;
+	measure: Measure;
+	onSegmentClick: (args: { dimensionValue: string | null }) => void;
+	results: DataResponse;
+	showLegend?: boolean;
+	showTooltips?: boolean;
+	showValueLabels?: boolean;
+	title?: string;
+};
 
 export const meta = {
-  name: 'PieChart',
-  label: 'Pie Chart',
-  category: 'Pie Charts',
-  inputs: [
-    {
-        name: 'dataset',
-        type: 'dataset',
-        label: 'Dataset',
-        required: true,
-        category: 'Chart Data'
-    },
-    {
-        name: 'measure',
-        type: 'measure',
-        label: 'Measure',
-        config: {
-            dataset: 'dataset', // restricts measure options to the selected dataset
-        },
-        required: true,
-        category: 'Chart Data'
-    },
-    {
-        name: 'dimension',
-        type: 'dimension',
-        label: 'Dimension',
-        config: {
-            dataset: 'dataset',
-        },
-        required: true,
-        category: 'Chart Data'
-    },
-    {...title},
-    {...description},  
-    {...showLegend},
-    {...maxLegendItems},  
-    {...showToolTips}, 
-    {...showValueLabels}  
-  ],
-  events: [
-    {
-        name: 'onSegmentClick',
-        label: 'A segment is clicked',
-        properties: [
-        {
-            name: 'dimensionValue',
-            label: 'Clicked Dimension',
-            type: 'string',
-        }
-        ],
-    },
-],
+	name: 'PieChart',
+	label: 'Pie Chart',
+	category: 'Pie Charts',
+	inputs: [
+		{
+			name: 'dataset',
+			type: 'dataset',
+			label: 'Dataset',
+			required: true,
+			category: 'Chart Data',
+		},
+		{
+			name: 'measure',
+			type: 'measure',
+			label: 'Measure',
+			config: {
+				dataset: 'dataset', // restricts measure options to the selected dataset
+			},
+			required: true,
+			category: 'Chart Data',
+		},
+		{
+			name: 'dimension',
+			type: 'dimension',
+			label: 'Dimension',
+			config: {
+				dataset: 'dataset',
+			},
+			required: true,
+			category: 'Chart Data',
+		},
+		{ ...title },
+		{ ...description },
+		{ ...showLegend },
+		{ ...maxLegendItems },
+		{ ...showToolTips },
+		{ ...showValueLabels },
+	],
+	events: [
+		{
+			name: 'onSegmentClick',
+			label: 'A segment is clicked',
+			properties: [
+				{
+					name: 'dimensionValue',
+					label: 'Clicked Dimension',
+					type: 'string',
+				},
+			],
+		},
+	],
 } as const satisfies EmbeddedComponentMeta;
 
 export default defineComponent(PieChart, meta, {
-  props: (inputs: Inputs<typeof meta>) => {
-    return {
-        ...inputs,
-        results: loadData({
-            from: inputs.dataset,
-            measures: [inputs.measure], 
-            dimensions: [inputs.dimension], 
-        })
-    };
-  },
-  events: {
-    onSegmentClick: (value) => {
-      return {
-        dimensionValue: value.dimensionValue || Value.noFilter(),
-      };
-    },
-  },
+	props: (inputs: Inputs<typeof meta>) => {
+		return {
+			...inputs,
+			results: loadData({
+				from: inputs.dataset,
+				measures: [inputs.measure],
+				dimensions: [inputs.dimension],
+			}),
+		};
+	},
+	events: {
+		onSegmentClick: (value) => {
+			return {
+				dimensionValue: value.dimensionValue || Value.noFilter(),
+			};
+		},
+	},
 });

--- a/src/remarkable-ui/charts/Pie/PieChart/index.tsx
+++ b/src/remarkable-ui/charts/Pie/PieChart/index.tsx
@@ -1,42 +1,38 @@
-// Third Party Libraries
-import React from 'react';
-
 // Local Libraries
-import Card from '../../../shared/Card';
 import BasePieChart from '../../../shared/BasePieChart';
+import Card from '../../../shared/Card';
 import { PieChartProps } from './PieChart.emb';
 
 export default ({
-    description,
-    dimension,
-    maxLegendItems,
-    measure,
-    onSegmentClick,
-    results,
-    showLegend,
-    showTooltips,
-    showValueLabels,
-    title,  
+	description,
+	dimension,
+	maxLegendItems,
+	measure,
+	onSegmentClick,
+	results,
+	showLegend,
+	showTooltips,
+	showValueLabels,
+	title,
 }: PieChartProps) => {
-
-    return (
-        <Card
-            data={results.data}            
-            description={description}
-            errorMessage={results.error}
-            isLoading={results.isLoading}
-            title={title}
-        >
-            <BasePieChart
-                dimension={dimension}
-                measure={measure}
-                onSegmentClick={onSegmentClick}
-                results={results}
-                showDataLabels={showValueLabels ? 'auto' : false}
-                showLegend={showLegend}
-                showTooltips={showTooltips}
-                maxLegendItems={maxLegendItems}
-            />        
-        </Card>
-    );
+	return (
+		<Card
+			data={results.data}
+			description={description}
+			errorMessage={results.error}
+			isLoading={results.isLoading}
+			title={title}
+		>
+			<BasePieChart
+				dimension={dimension}
+				maxLegendItems={maxLegendItems}
+				measure={measure}
+				onSegmentClick={onSegmentClick}
+				results={results}
+				showDataLabels={showValueLabels ? 'auto' : false}
+				showLegend={showLegend}
+				showTooltips={showTooltips}
+			/>
+		</Card>
+	);
 };

--- a/src/themes/remarkableTheme/remarkableTheme.ts
+++ b/src/themes/remarkableTheme/remarkableTheme.ts
@@ -1,44 +1,42 @@
 //this is where the default remarkable theme will live
-//may want to break out css base variables, so they're not included in the theme. 
-//And import them somewhere else. 
+//may want to break out css base variables, so they're not included in the theme.
+//And import them somewhere else.
 
 import { Theme } from './theme';
-import { cssVariables } from './cssVariables'
-
-const CHART_COLORS = [
-    "#5F6CAF",
-    "#EF8A88", 
-    "#8FBED8",
-    "#F4B992",
-    "#75B9B0",
-    "#B5AEE0",
-    "#D28CA5",
-    "#D4A373",
-    "#A9C5A0",
-    "#8CA587"
-];
+import { cssVariables } from './cssVariables';
 
 const CHART_BORDERS = [
-    "#5F6CAF",
-    "#EF8A88", 
-    "#8FBED8",
-    "#F4B992",
-    "#75B9B0",
-    "#B5AEE0",
-    "#D28CA5",
-    "#D4A373",
-    "#A9C5A0",
-    "#8CA587"
+	'#5F6CAF',
+	'#EF8A88',
+	'#8FBED8',
+	'#F4B992',
+	'#75B9B0',
+	'#B5AEE0',
+	'#D28CA5',
+	'#D4A373',
+	'#A9C5A0',
+	'#8CA587',
 ];
- 
+
+const CHART_COLORS = [
+	'#5F6CAF',
+	'#EF8A88',
+	'#8FBED8',
+	'#F4B992',
+	'#75B9B0',
+	'#B5AEE0',
+	'#D28CA5',
+	'#D4A373',
+	'#A9C5A0',
+	'#8CA587',
+];
+
 export const remarkableTheme: Theme = {
 	styles: cssVariables,
 	charts: {
+		borderColors: CHART_BORDERS,
 		colors: CHART_COLORS,
-		borderColors: CHART_BORDERS, 
-	}
-}
-
-
+	},
+};
 
 export default remarkableTheme;

--- a/src/themes/remarkableTheme/theme.ts
+++ b/src/themes/remarkableTheme/theme.ts
@@ -1,30 +1,21 @@
-import { valueProps, configProps } from "../../remarkable-ui/utils/formatUtils";
-import { DropdownItem } from "../../remarkable-ui/shared/BaseDropdown";
+import { configProps, valueProps } from '../../remarkable-ui/utils/formatUtils';
+import { DropdownItem } from '../../remarkable-ui/shared/BaseDropdown';
 
 export type Theme = {
-	styles?: {
-		[key: string]: string; //todo: add specific variables and types
-	};
 	charts: {
 		colors: string[];
 		borderColors?: string[];
-		legendPosition?: "top" | "right" | "bottom" | "left";
+		legendPosition?: 'top' | 'right' | 'bottom' | 'left';
 	};
-	customFormatFunction?: (value: valueProps, config?: configProps) => string;
-	customDateFormatFunction?: (
-		value: valueProps,
-		config?: configProps,
-	) => string;
-	customTextFormatFunction?: (
-		value: valueProps,
-		config?: configProps,
-	) => string;
-	customNumberFormatFunction?: (
-		value: valueProps,
-		config?: configProps,
-	) => string;
+	customDateFormatFunction?: (value: valueProps, config?: configProps) => string;
 	customDateFormats?: {
 		[key: string]: string;
 	};
 	customExportOptions?: DropdownItem[];
+	customFormatFunction?: (value: valueProps, config?: configProps) => string;
+	customNumberFormatFunction?: (value: valueProps, config?: configProps) => string;
+	customTextFormatFunction?: (value: valueProps, config?: configProps) => string;
+	styles?: {
+		[key: string]: string; //todo: add specific variables and types
+	};
 };


### PR DESCRIPTION
Went through some Remarkable UI stuff - basically made a lot of changes via prettier and then also alphabetized a lot of stuff. While I was in there I added an optional `innerLabelText` input for the donut chart that replaces the current "Some Label" text.

Going to do this in batches to keep these PRs at least semi-manageable :grin:
