### PR TITLE
RUI-45: improvements

### DIFF
--- a/src/remarkable-ui-embeddables/components/charts/pies/pies.utils.ts
+++ b/src/remarkable-ui-embeddables/components/charts/pies/pies.utils.ts
@@ -6,6 +6,7 @@ import { remarkableTheme } from '../../../theme/theme.constants';
 import { getThemeFormatter } from '../../../theme/formatter/formatter.utils';
 import { getColor } from '../../../theme/styles/styles.utils';
 import { chartColors } from '../../../../remarkable-ui';
+import { i18n } from '../../../theme/i18n/i18n';
 
 export const getPieChartData = (
   props: {
@@ -50,9 +51,16 @@ export const getPieChartData = (
   );
 
   return {
-    labels: groupedData.map((item) =>
-      themeFormatter.data(props.dimension, item[props.dimension.name]),
-    ),
+    labels: groupedData.map((item) => {
+      const value = item[props.dimension.name];
+      const formattedValue = themeFormatter.data(props.dimension, value);
+
+      // If formatter did not work, try i18n translation
+      if (value === formattedValue) {
+        return i18n.t(value);
+      }
+      return formattedValue;
+    }),
     datasets: [
       {
         data: groupedData.map((item) => item[props.measure.name]),

--- a/src/remarkable-ui-embeddables/theme/formatter/formatter.constants.ts
+++ b/src/remarkable-ui-embeddables/theme/formatter/formatter.constants.ts
@@ -41,7 +41,7 @@ const numberFormatter = (
   if (currency && !isValidCurrency(locale, currency)) {
     return {
       format: (value: number | bigint): string =>
-        `${Intl.NumberFormat(locale, { ...options, currency: undefined, style: undefined }).format(value)} ${currency}`,
+        `${currency} ${Intl.NumberFormat(locale, { ...options, currency: undefined, style: undefined }).format(value)}`,
     };
   }
 


### PR DESCRIPTION
This PR fixes the fallback currency to appear always on the left side of the number, and it fixes the i18n for the other, when the type of the dimension is other than string

<img width="1526" height="695" alt="image" src="https://github.com/user-attachments/assets/6368ec46-8720-4ab8-9a5d-c8e4bc890fbc" />
