### PR TITLE
RUI-000: export constants

### DIFF
--- a/.changeset/khaki-pants-repair.md
+++ b/.changeset/khaki-pants-repair.md
@@ -1,0 +1,5 @@
+---
+'@embeddable.com/remarkable-ui': patch
+---
+
+Export emb input constants

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -7,3 +7,4 @@ export type {
   StringFormatter,
   ThemeFormatter,
 } from './remarkable-pro/theme/formatter/formatter.types';
+export * from './remarkable-pro/components/component.constants';


### PR DESCRIPTION
# Why is this pull-request needed?

This PR releases a new version that exports the emb input constants, to be reused for custom components