### PR TITLE
RUI-62: Improve chart card content display

### DIFF
--- a/.changeset/free-states-strive.md
+++ b/.changeset/free-states-strive.md
@@ -1,0 +1,5 @@
+---
+'@embeddable.com/remarkable-ui': patch
+---
+
+Improve chart card content display

--- a/src/remarkable-pro/components/charts/pies/DonutChartPro/DonutChartPro.emb.ts
+++ b/src/remarkable-pro/components/charts/pies/DonutChartPro/DonutChartPro.emb.ts
@@ -1,6 +1,6 @@
 import { Value, loadData } from '@embeddable.com/core';
 import { defineComponent, EmbeddedComponentMeta, Inputs } from '@embeddable.com/react';
-import ReadyMadeDonutChart from './index';
+import DonutChartPro from './index';
 import {
   dimension,
   dataset,
@@ -43,7 +43,7 @@ export const meta = {
   ],
 } as const satisfies EmbeddedComponentMeta;
 
-export default defineComponent(ReadyMadeDonutChart, meta, {
+export default defineComponent(DonutChartPro, meta, {
   props: (inputs: Inputs<typeof meta>) => {
     return {
       ...inputs,

--- a/src/remarkable-pro/components/charts/pies/DonutLabelChartPro/DonutLabelChartPro.emb.ts
+++ b/src/remarkable-pro/components/charts/pies/DonutLabelChartPro/DonutLabelChartPro.emb.ts
@@ -1,11 +1,10 @@
+import DonutChartPro from './index';
 import { Value, loadData } from '@embeddable.com/core';
 import { defineComponent, EmbeddedComponentMeta, Inputs } from '@embeddable.com/react';
-
-import PieChart from './index';
 import {
-  dimension,
   dataset,
   description,
+  dimension,
   measure,
   maxLegendItems,
   showLegend,
@@ -53,7 +52,7 @@ export const meta = {
   ],
 } as const satisfies EmbeddedComponentMeta;
 
-export default defineComponent(PieChart, meta, {
+export default defineComponent(DonutChartPro, meta, {
   props: (inputs: Inputs<typeof meta>) => {
     return {
       ...inputs,

--- a/src/remarkable-pro/components/charts/pies/PieChartPro/PieChartPro.emb.ts
+++ b/src/remarkable-pro/components/charts/pies/PieChartPro/PieChartPro.emb.ts
@@ -1,11 +1,10 @@
 import { Value, loadData } from '@embeddable.com/core';
 import { defineComponent, EmbeddedComponentMeta, Inputs } from '@embeddable.com/react';
-
-import ReadyMadePieChart from './index';
+import PieChartPro from './index';
 import {
-  dimension,
   dataset,
   description,
+  dimension,
   measure,
   maxLegendItems,
   showLegend,
@@ -44,7 +43,7 @@ export const meta = {
   ],
 } as const satisfies EmbeddedComponentMeta;
 
-export default defineComponent(ReadyMadePieChart, meta, {
+export default defineComponent(PieChartPro, meta, {
   props: (inputs: Inputs<typeof meta>) => {
     return {
       ...inputs,

--- a/src/remarkable-pro/components/charts/shared/ChartCard/ChartCard.stories.tsx
+++ b/src/remarkable-pro/components/charts/shared/ChartCard/ChartCard.stories.tsx
@@ -2,7 +2,7 @@ import type { Meta } from '@storybook/react-webpack5';
 import { ChartCard } from './ChartCard';
 import { PieChart } from '../../../../../remarkable-ui';
 import { ChartData } from 'chart.js';
-import { defaultPieChartOptions } from '../../../../../remarkable-ui/charts/pies/pies.constants';
+import { defaultPieChartOptions } from '../../../../../remarkable-ui';
 
 const meta = {
   component: ChartCard,

--- a/src/remarkable-ui/charts/charts.module.css
+++ b/src/remarkable-ui/charts/charts.module.css
@@ -1,0 +1,5 @@
+.chartContainer {
+  flex-grow: 1; /* allow it to take remaining space */
+  min-height: 0; /* prevent overflow issues */
+  position: relative; /* needed for Chart.js responsive sizing */
+}

--- a/src/remarkable-ui/charts/pies/DonutChart.tsx
+++ b/src/remarkable-ui/charts/pies/DonutChart.tsx
@@ -1,12 +1,13 @@
 import { FC, useRef } from 'react';
-import { mergician } from 'mergician';
-import { BasePieChartProps } from './pies.types';
-import { defaultDonutChartOptions, defaultDonutLabelChartOptions } from './pies.constants';
 import { Pie } from 'react-chartjs-2';
 import { ArcElement, Chart as ChartJS, Legend, Tooltip } from 'chart.js';
 import ChartDataLabels from 'chartjs-plugin-datalabels';
 import AnnotationPlugin from 'chartjs-plugin-annotation';
+import { mergician } from 'mergician';
+import { BasePieChartProps } from './pies.types';
+import { defaultDonutChartOptions, defaultDonutLabelChartOptions } from './pies.constants';
 import { getPieData, getPieSegmentIndexClicked } from './pies.utils';
+import styles from '../charts.module.css';
 
 ChartJS.register(ArcElement, Tooltip, Legend, ChartDataLabels, AnnotationPlugin);
 
@@ -47,11 +48,13 @@ export const DonutChart: FC<DonutLabelChartProps> = ({
   };
 
   return (
-    <Pie
-      ref={chartRef}
-      data={getPieData(data)}
-      options={donutLabelOptions}
-      onClick={handleSegmentClick}
-    />
+    <div className={styles.chartContainer}>
+      <Pie
+        ref={chartRef}
+        data={getPieData(data)}
+        options={donutLabelOptions}
+        onClick={handleSegmentClick}
+      />
+    </div>
   );
 };

--- a/src/remarkable-ui/charts/pies/PieChart.tsx
+++ b/src/remarkable-ui/charts/pies/PieChart.tsx
@@ -1,11 +1,12 @@
 import { FC, useRef } from 'react';
-import { BasePieChartProps } from './pies.types';
-import { mergician } from 'mergician';
-import { defaultPieChartOptions } from './pies.constants';
 import { Pie } from 'react-chartjs-2';
 import { ArcElement, Chart as ChartJS, Legend, Tooltip } from 'chart.js';
-import { getPieData, getPieSegmentIndexClicked } from './pies.utils';
 import ChartDataLabels from 'chartjs-plugin-datalabels';
+import { mergician } from 'mergician';
+import { BasePieChartProps } from './pies.types';
+import { defaultPieChartOptions } from './pies.constants';
+import { getPieData, getPieSegmentIndexClicked } from './pies.utils';
+import styles from '../charts.module.css';
 
 ChartJS.register(ArcElement, Tooltip, Legend, ChartDataLabels);
 
@@ -22,6 +23,13 @@ export const PieChart: FC<PieChartProps> = ({ data, options = {}, onSegmentClick
   };
 
   return (
-    <Pie ref={chartRef} data={getPieData(data)} options={pieOptions} onClick={handleSegmentClick} />
+    <div className={styles.chartContainer}>
+      <Pie
+        ref={chartRef}
+        data={getPieData(data)}
+        options={pieOptions}
+        onClick={handleSegmentClick}
+      />
+    </div>
   );
 };

--- a/src/remarkable-ui/index.ts
+++ b/src/remarkable-ui/index.ts
@@ -21,6 +21,7 @@ export { SingleSelectField } from './editors/select/SingleSelectField/SingleSele
 // Charts
 export { DonutChart } from './charts/pies/DonutChart';
 export { PieChart } from './charts/pies/PieChart';
+export { defaultPieChartOptions } from './charts/pies/pies.constants';
 
 // Constants
 export { chartColors } from './charts/charts.constants';


### PR DESCRIPTION
# Why is this pull-request needed?

Charts inside the ChartCard need to occupy the available space, without being cut.

# Main changes

Add container around charts, so they can occupy the available space.

# Evidence

element on the top and bottom

<img width="1440" height="486" alt="image" src="https://github.com/user-attachments/assets/42789825-d78a-4952-9ee4-bd6116a4e15a" />
