### PR TITLE
RUI-62: Fix select content width behavior. Export the getThemeFormatter. Make stringFormatter available from the getThemeFormatter.

### DIFF
--- a/.changeset/good-bananas-open.md
+++ b/.changeset/good-bananas-open.md
@@ -1,0 +1,5 @@
+---
+'@embeddable.com/remarkable-ui': patch
+---
+
+Fix select content width behavior. Export the getThemeFormatter. Make stringFormatter available from the getThemeFormatter.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@embeddable.com/remarkable-ui",
-  "version": "0.0.4",
+  "version": "0.0.11",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@embeddable.com/remarkable-ui",
-      "version": "0.0.4",
+      "version": "0.0.11",
       "dependencies": {
         "@changesets/cli": "^2.29.6",
         "@radix-ui/react-dropdown-menu": "^2.1.15",

--- a/src/remarkable-pro/components/charts/shared/ChartCard/ChartCardMenuPro/ChartCardMenuPro.tsx
+++ b/src/remarkable-pro/components/charts/shared/ChartCard/ChartCardMenuPro/ChartCardMenuPro.tsx
@@ -32,9 +32,9 @@ export const ChartCardMenuPro: React.FC<ChartCardMenuProProps> = (props) => {
     startAction(() => onClick({ ...props, theme }));
   };
 
-  const options = theme.charts.chartCardMenuPro.options;
+  const options = theme.charts?.chartCardMenuPro?.options ?? [];
 
-  if (!options) {
+  if (options.length === 0) {
     return null;
   }
 
@@ -45,7 +45,7 @@ export const ChartCardMenuPro: React.FC<ChartCardMenuProProps> = (props) => {
       triggerComponent={isLoading ? <ChartCardLoading /> : <IconButton icon={IconDotsVertical} />}
     >
       <SelectList className={styles.list} autoFocus>
-        {theme.charts?.chartCardMenuPro?.options?.map((option, index) => {
+        {options.map((option, index) => {
           const label = i18n.t(option.labelKey);
 
           return (

--- a/src/remarkable-pro/index.ts
+++ b/src/remarkable-pro/index.ts
@@ -15,6 +15,7 @@ export type {
   StringFormatter,
   ThemeFormatter,
 } from './theme/formatter/formatter.types';
+export { getThemeFormatter } from './theme/formatter/formatter.utils';
 
 // Components utils
 export { resolveI18nProps } from './components/component.utils';

--- a/src/remarkable-pro/theme/formatter/formatter.constants.ts
+++ b/src/remarkable-pro/theme/formatter/formatter.constants.ts
@@ -28,6 +28,12 @@ const isValidCurrency = (locale: Intl.LocalesArgument, code: string): boolean =>
   }
 };
 
+const stringFormatter = (): StringFormatter => {
+  return {
+    format: (key: string): string => i18n.t(key),
+  };
+};
+
 const defaultNumberFormatterOptions: Intl.NumberFormatOptions = {};
 
 const numberFormatter = (
@@ -73,9 +79,13 @@ const defaultDateTimeFormatOptions: Intl.DateTimeFormatOptions = {
   second: 'numeric',
 };
 
-const dateTimeFormatter = (theme: Theme): DateTimeFormatter => {
+const dateTimeFormatter = (
+  theme: Theme,
+  options?: Intl.DateTimeFormatOptions,
+): DateTimeFormatter => {
   const locale = getLocale(theme.formatter.locale);
-  const { year, month, day, hour, minute, second } = theme.formatter.defaultDateTimeFormatOptions;
+  const { year, month, day, hour, minute, second } =
+    options ?? theme.formatter.defaultDateTimeFormatOptions;
   return new Intl.DateTimeFormat(locale, { year, month, day, hour, minute, second });
 };
 
@@ -127,7 +137,12 @@ const dataOthersFormatter = (theme: Theme, key: DimensionOrMeasure): StringForma
 
   return {
     format: (value: string) => {
+      if (!value) {
+        return '';
+      }
+
       const stringValue = value.toString();
+
       return i18n.t(
         [
           `${prefix}.${name}.${stringValue}`, // e.g. 'Dimension.customers.country.Germany': 'Deutschland',
@@ -150,6 +165,7 @@ export const remarkableThemeFormatter: ThemeFormatter = {
   defaultNumberFormatterOptions,
   defaultDateTimeFormatOptions,
 
+  stringFormatter,
   numberFormatter,
   dateTimeFormatter,
 

--- a/src/remarkable-pro/theme/formatter/formatter.types.ts
+++ b/src/remarkable-pro/theme/formatter/formatter.types.ts
@@ -17,6 +17,7 @@ export type ThemeFormatter = {
   defaultDateTimeFormatOptions: Intl.DateTimeFormatOptions;
 
   // Default formatters
+  stringFormatter: () => StringFormatter;
   numberFormatter: (theme: Theme, options?: Intl.NumberFormatOptions) => NumberFormatter;
   dateTimeFormatter: (theme: Theme, options?: Intl.DateTimeFormatOptions) => DateTimeFormatter;
 

--- a/src/remarkable-pro/theme/formatter/formatter.utils.ts
+++ b/src/remarkable-pro/theme/formatter/formatter.utils.ts
@@ -5,6 +5,7 @@ import { cache } from '../../utils.ts/cache.utils';
 import { isValidISODate } from '../../utils.ts/data.utils';
 
 export type GetThemeFormatter = {
+  string: (key: string) => string;
   number: (value: number | bigint, options?: Intl.NumberFormatOptions) => string;
   dateTime: (value: Date, options?: Intl.DateTimeFormatOptions) => string;
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -33,6 +34,7 @@ export const getThemeFormatter = (theme: Theme): GetThemeFormatter => {
   );
 
   return {
+    string: (key: string) => theme.formatter.stringFormatter().format(key),
     number: (value: number | bigint, options?: Intl.NumberFormatOptions): string => {
       return cachedNumberFormatter(options).format(value);
     },

--- a/src/remarkable-ui/editors/select/SingleSelectField/SingleSelectField.stories.tsx
+++ b/src/remarkable-ui/editors/select/SingleSelectField/SingleSelectField.stories.tsx
@@ -11,7 +11,42 @@ export default meta;
 
 type Story = StoryObj<typeof meta>;
 
+const mockLongOptions: SelectListOptionProps[] = [
+  {
+    value: 'red',
+    label:
+      'Red - The color of passion and energy, often associated with excitement, love, and intensity.',
+  },
+  {
+    value: 'green',
+    label: 'Green - The color of nature and growth, symbolizing renewal, harmony, and freshness.',
+  },
+  { value: 'yellow', label: 'Yellow - The color of sunshine, happiness, and optimism.' },
+  {
+    value: 'orange',
+    label: 'Orange - A vibrant color representing enthusiasm, creativity, and encouragement.',
+  },
+  { value: 'purple', label: 'Purple - Associated with royalty, luxury, and ambition.' },
+  { value: 'pink', label: 'Pink - The color of compassion, nurturing, and love.' },
+  { value: 'brown', label: 'Brown - The color of stability, reliability, and comfort.' },
+  { value: 'gray', label: 'Gray - A neutral color representing balance and calm.' },
+  { value: 'black', label: 'Black - The color of elegance, mystery, and sophistication.' },
+];
+
 const mockOptions: SelectListOptionProps[] = [
+  { value: 'red', label: 'Red' },
+  { value: 'green', label: 'Green' },
+  { value: 'blue', label: 'Blue' },
+  { value: 'yellow', label: 'Yellow' },
+  { value: 'orange', label: 'Orange' },
+  { value: 'purple', label: 'Purple' },
+  { value: 'pink', label: 'Pink' },
+  { value: 'brown', label: 'Brown' },
+  { value: 'gray', label: 'Gray' },
+  { value: 'black', label: 'Black' },
+];
+
+const mockOptionsWithRightLabel: SelectListOptionProps[] = [
   { value: 'red', label: 'Red', rightLabel: 'This is color Red' },
   { value: 'green', label: 'Green', rightLabel: 'This is color Green' },
   { value: 'blue', label: 'Blue', rightLabel: 'This is color Blue' },
@@ -51,11 +86,36 @@ export const Disabled: Story = {
   },
 };
 
-export const Small = () => (
+export const SmallButtonLongText = () => (
   <div style={{ width: 200 }}>
     <SingleSelectField
+      isClearable
+      value={mockLongOptions[0]!.value}
+      options={mockLongOptions}
+      isSearchable
+      onChange={(value) => console.log('onChange', value)}
+    />
+  </div>
+);
+
+export const SmallButtonSmallText = () => (
+  <div style={{ width: 200 }}>
+    <SingleSelectField
+      isClearable
       value={mockOptions[0]!.value}
       options={mockOptions}
+      isSearchable
+      onChange={(value) => console.log('onChange', value)}
+    />
+  </div>
+);
+
+export const SmallButtonRightSideLabel = () => (
+  <div style={{ width: 200 }}>
+    <SingleSelectField
+      isClearable
+      value={mockOptionsWithRightLabel[0]!.value}
+      options={mockOptionsWithRightLabel}
       isSearchable
       onChange={(value) => console.log('onChange', value)}
     />

--- a/src/remarkable-ui/editors/select/shared/SelectButton/SelectButton.module.css
+++ b/src/remarkable-ui/editors/select/shared/SelectButton/SelectButton.module.css
@@ -16,12 +16,21 @@
   outline: none;
 }
 
+.button .rightContent {
+  flex-shrink: 0;
+}
+
 .button .leftContent {
-  display: flex;
-  align-items: center;
+  flex-grow: 1;
+  min-width: 0;
+  overflow: hidden;
+  white-space: nowrap;
+  text-overflow: ellipsis;
 }
 
 .button .leftContent span {
+  text-align: left;
+  display: block;
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;

--- a/src/remarkable-ui/editors/select/shared/SelectList/SelectList.module.css
+++ b/src/remarkable-ui/editors/select/shared/SelectList/SelectList.module.css
@@ -3,10 +3,11 @@
   flex-direction: column;
   outline: none;
   box-sizing: border-box;
-  width: max(
+  max-width: max(
     var(--radix-dropdown-menu-trigger-width),
     var(--em-select-menu-size-width-max-width, 25rem)
   );
+  min-width: var(--radix-dropdown-menu-trigger-width);
   padding: var(--em-padding-200, 0.5rem);
   max-height: var(--em-select-menu-list-size-max-height, 20rem);
   gap: var(--em-select-menu-list-gap-default, 0.5rem);

--- a/src/remarkable-ui/shared/Dropdown/Dropdown.tsx
+++ b/src/remarkable-ui/shared/Dropdown/Dropdown.tsx
@@ -25,7 +25,7 @@ export const Dropdown: FC<DropdownProps> = ({
       <DropdownMenu.Trigger asChild disabled={disabled}>
         {triggerComponent}
       </DropdownMenu.Trigger>
-      <DropdownMenu.Content side={side} align={align}>
+      <DropdownMenu.Content side={side} align={align} style={{ zIndex: 5 }}>
         {children}
       </DropdownMenu.Content>
     </DropdownMenu.Root>


### PR DESCRIPTION

# Why is this pull-request needed?

This Pr fix select content width behavior. Export the getThemeFormatter. Make stringFormatter available from the getThemeFormatter.


# Test evidence


https://github.com/user-attachments/assets/e5456ed8-25e2-4082-b0d4-7be0650293bb


