### PR TITLE
RUI-77: Support react 19

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@embeddable.com/remarkable-ui",
-  "version": "0.0.11",
+  "version": "0.0.17",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@embeddable.com/remarkable-ui",
-      "version": "0.0.11",
+      "version": "0.0.17",
       "dependencies": {
         "@changesets/cli": "^2.29.6",
         "@radix-ui/react-dropdown-menu": "^2.1.15",
@@ -23,10 +23,10 @@
         "xlsx": "^0.18.5"
       },
       "devDependencies": {
-        "@embeddable.com/core": "^2.10.7",
-        "@embeddable.com/react": "^2.10.8",
-        "@embeddable.com/sdk-core": "^4.0.2",
-        "@embeddable.com/sdk-react": "^4.0.2",
+        "@embeddable.com/core": "^2.11.1",
+        "@embeddable.com/react": "^2.11.0",
+        "@embeddable.com/sdk-core": "^4.1.2",
+        "@embeddable.com/sdk-react": "^4.0.6",
         "@eslint/css": "^0.10.0",
         "@eslint/js": "^9.31.0",
         "@storybook/addon-webpack5-compiler-swc": "^3.0.0",
@@ -60,8 +60,8 @@
         "@swc/core-linux-x64-gnu": "^1.13.5"
       },
       "peerDependencies": {
-        "react": "^18.2.0",
-        "react-dom": "^18.2.0"
+        "react": "18.2.0 || ^19.0.0",
+        "react-dom": "18.2.0 || ^19.0.0"
       }
     },
     "node_modules/@adobe/css-tools": {
@@ -803,9 +803,9 @@
       }
     },
     "node_modules/@embeddable.com/core": {
-      "version": "2.11.0",
-      "resolved": "https://registry.npmjs.org/@embeddable.com/core/-/core-2.11.0.tgz",
-      "integrity": "sha512-idcpDkPY5GA2CIT49zO2LViTeegjaGls2fUpjxUPtR5Swwhb8SDCFBKlPspJsq+u/rcSM6MZ9D8EFC7wJ0VrwA==",
+      "version": "2.11.1",
+      "resolved": "https://registry.npmjs.org/@embeddable.com/core/-/core-2.11.1.tgz",
+      "integrity": "sha512-ndwYJqdvV3WM9ETt4ZniBPKPo/c3ClRpa9FLJlkIptLVU1wEvikb1+hCvZN6Jd87lQWt0DNnKMcnYIOToFLEUA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -814,26 +814,26 @@
       }
     },
     "node_modules/@embeddable.com/react": {
-      "version": "2.10.10",
-      "resolved": "https://registry.npmjs.org/@embeddable.com/react/-/react-2.10.10.tgz",
-      "integrity": "sha512-b2sqJVW9n3FkzIVv7uJXPfoSXk8DbDbX152uj9kwyhQwFHaQ0cXHtmR3QPIthpdklaVQoJ5LKhBzmaszebx1rQ==",
+      "version": "2.11.0",
+      "resolved": "https://registry.npmjs.org/@embeddable.com/react/-/react-2.11.0.tgz",
+      "integrity": "sha512-Wbjfggu/iwQjVdMtCGZXZvaAfgsYWqyR/HAIg3prhHDCKbhYQW6toKa0+MuMQMIeNB+tvDAWyy6D3wd6IizSBA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@embeddable.com/core": "2.11.0"
+        "@embeddable.com/core": "2.11.1"
       },
       "peerDependencies": {
-        "react": "^16.8.0 || ^17.0.0 || ^18.0.0"
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
       }
     },
     "node_modules/@embeddable.com/sdk-core": {
-      "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/@embeddable.com/sdk-core/-/sdk-core-4.1.1.tgz",
-      "integrity": "sha512-99xiCM4Gw/M0l7vkSersFA5YzLZU1O5s4ej+d7c04kt+wcXLnrcX0b9CaqPfeZeYDOwpVmq/HvTwloKnkRfFfQ==",
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/@embeddable.com/sdk-core/-/sdk-core-4.1.2.tgz",
+      "integrity": "sha512-WtQJ5nOy3IL8ex8mvI2OV+TE5BFGzUXmHhor/F9dMTFYZTOGjMfgZETrD6Ls24h4EEC5roo9lrc7rn70yi21MQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@embeddable.com/core": "2.11.0",
+        "@embeddable.com/core": "2.11.1",
         "@embeddable.com/sdk-utils": "0.8.2",
         "@inquirer/prompts": "^7.2.1",
         "@stencil/core": "^4.23.0",
@@ -892,16 +892,16 @@
       }
     },
     "node_modules/@embeddable.com/sdk-react": {
-      "version": "4.0.5",
-      "resolved": "https://registry.npmjs.org/@embeddable.com/sdk-react/-/sdk-react-4.0.5.tgz",
-      "integrity": "sha512-m5Y4Rs+fzBESNn8qGhbIP8Mux5oFtVjKMqL2X2jj9VuUn0w/pZfo69T1r+gpdTYtODpVBrsZv1VDst+odUrlTQ==",
+      "version": "4.0.6",
+      "resolved": "https://registry.npmjs.org/@embeddable.com/sdk-react/-/sdk-react-4.0.6.tgz",
+      "integrity": "sha512-LuI69bkMQULugdlcawmuh2xUUWqt73rFc/S6ggiBt8XUH1qCuc+MMe9Xakh9e1y/9Vx1GVhggdlXfeUuWGOTMw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@babel/generator": "^7.23.0",
         "@babel/parser": "^7.26.2",
         "@babel/traverse": "^7.24.7",
-        "@embeddable.com/sdk-core": "4.1.1",
+        "@embeddable.com/sdk-core": "4.1.2",
         "@embeddable.com/sdk-utils": "0.8.2",
         "@happy-dom/global-registrator": "^15.11.0",
         "@vitejs/plugin-react": "^4.3.2",
@@ -4474,14 +4474,14 @@
       }
     },
     "node_modules/@storybook/react": {
-      "version": "9.1.3",
-      "resolved": "https://registry.npmjs.org/@storybook/react/-/react-9.1.3.tgz",
-      "integrity": "sha512-CgJMk4Y8EfoFxWiTB53QxnN+nQbAkw+NBaNjsaaeDNOE1R0ximP/fn5b2jcLvM+b5ojjJiJL1QCzFyoPWImHIQ==",
+      "version": "9.1.5",
+      "resolved": "https://registry.npmjs.org/@storybook/react/-/react-9.1.5.tgz",
+      "integrity": "sha512-fBVP7Go09gzpImtaMcZ2DipLEWdWeTmz7BrACr3Z8uCyKcoH8/d1Wv0JgIiBo1UKDh5ZgYx5pLafaPNqmVAepg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@storybook/global": "^5.0.0",
-        "@storybook/react-dom-shim": "9.1.3"
+        "@storybook/react-dom-shim": "9.1.5"
       },
       "engines": {
         "node": ">=20.0.0"
@@ -4493,7 +4493,7 @@
       "peerDependencies": {
         "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0-beta",
         "react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0-beta",
-        "storybook": "^9.1.3",
+        "storybook": "^9.1.5",
         "typescript": ">= 4.9.x"
       },
       "peerDependenciesMeta": {
@@ -4523,9 +4523,9 @@
       }
     },
     "node_modules/@storybook/react-dom-shim": {
-      "version": "9.1.3",
-      "resolved": "https://registry.npmjs.org/@storybook/react-dom-shim/-/react-dom-shim-9.1.3.tgz",
-      "integrity": "sha512-zIgFwZqV8cvE+lzJDcD13rItxoWyYNUWu7eJQAnHz5RnyHhpu6rFgQej7i6J3rPmy9xVe+Rq6XsXgDNs6pIekQ==",
+      "version": "9.1.5",
+      "resolved": "https://registry.npmjs.org/@storybook/react-dom-shim/-/react-dom-shim-9.1.5.tgz",
+      "integrity": "sha512-blSq9uzSYnfgEYPHYKgM5O14n8hbXNiXx2GiVJyDSg8QPNicbsBg+lCb1TC7/USfV26pNZr/lGNNKGkcCEN6Gw==",
       "dev": true,
       "license": "MIT",
       "funding": {
@@ -4535,7 +4535,7 @@
       "peerDependencies": {
         "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0-beta",
         "react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0-beta",
-        "storybook": "^9.1.3"
+        "storybook": "^9.1.5"
       }
     },
     "node_modules/@storybook/react-webpack5": {
@@ -4566,6 +4566,51 @@
         "typescript": {
           "optional": true
         }
+      }
+    },
+    "node_modules/@storybook/react-webpack5/node_modules/@storybook/react": {
+      "version": "9.1.3",
+      "resolved": "https://registry.npmjs.org/@storybook/react/-/react-9.1.3.tgz",
+      "integrity": "sha512-CgJMk4Y8EfoFxWiTB53QxnN+nQbAkw+NBaNjsaaeDNOE1R0ximP/fn5b2jcLvM+b5ojjJiJL1QCzFyoPWImHIQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@storybook/global": "^5.0.0",
+        "@storybook/react-dom-shim": "9.1.3"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/storybook"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0-beta",
+        "react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0-beta",
+        "storybook": "^9.1.3",
+        "typescript": ">= 4.9.x"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@storybook/react-webpack5/node_modules/@storybook/react-dom-shim": {
+      "version": "9.1.3",
+      "resolved": "https://registry.npmjs.org/@storybook/react-dom-shim/-/react-dom-shim-9.1.3.tgz",
+      "integrity": "sha512-zIgFwZqV8cvE+lzJDcD13rItxoWyYNUWu7eJQAnHz5RnyHhpu6rFgQej7i6J3rPmy9xVe+Rq6XsXgDNs6pIekQ==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/storybook"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0-beta",
+        "react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0-beta",
+        "storybook": "^9.1.3"
       }
     },
     "node_modules/@swc-node/core": {
@@ -5302,9 +5347,9 @@
       }
     },
     "node_modules/@types/semver": {
-      "version": "7.7.0",
-      "resolved": "https://registry.npmjs.org/@types/semver/-/semver-7.7.0.tgz",
-      "integrity": "sha512-k107IF4+Xr7UHjwDc7Cfd6PRQfbdkiRabXGRjo07b4WyPahFBZCZ1sE+BNxYIJPPg73UkfOsVOLwqVc/6ETrIA==",
+      "version": "7.7.1",
+      "resolved": "https://registry.npmjs.org/@types/semver/-/semver-7.7.1.tgz",
+      "integrity": "sha512-FmgJfu+MOcQ370SD0ev7EI8TlCAfKYU+B4m5T3yXc1CiRN94g/SZPtsCkk506aUDtlMnFZvasDwHHUcZUEaYuA==",
       "dev": true,
       "license": "MIT"
     },
@@ -11705,6 +11750,7 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
       "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/js-yaml": {
@@ -12369,6 +12415,7 @@
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.4.0.tgz",
       "integrity": "sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "js-tokens": "^3.0.0 || ^4.0.0"
@@ -14361,14 +14408,11 @@
       }
     },
     "node_modules/react": {
-      "version": "18.3.1",
-      "resolved": "https://registry.npmjs.org/react/-/react-18.3.1.tgz",
-      "integrity": "sha512-wS+hAgJShR0KhEvPJArfuPVN1+Hz1t0Y6n5jLrGQbkb4urgPE/0Rve+1kMB1v/oWgHgm4WIcV+i7F2pTVj+2iQ==",
+      "version": "19.1.1",
+      "resolved": "https://registry.npmjs.org/react/-/react-19.1.1.tgz",
+      "integrity": "sha512-w8nqGImo45dmMIfljjMwOGtbmC/mk4CMYhWIicdSflH91J9TyCyczcPFXJzrZ/ZXcgGRFeP6BU0BEJTw6tZdfQ==",
       "license": "MIT",
       "peer": true,
-      "dependencies": {
-        "loose-envify": "^1.1.0"
-      },
       "engines": {
         "node": ">=0.10.0"
       }
@@ -14429,17 +14473,16 @@
       }
     },
     "node_modules/react-dom": {
-      "version": "18.3.1",
-      "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-18.3.1.tgz",
-      "integrity": "sha512-5m4nQKp+rZRb09LNH59GM4BxTh9251/ylbKIbpe7TpGxfJ+9kv6BLkLBXIjjspbgbnIBNqlI23tRnTWT0snUIw==",
+      "version": "19.1.1",
+      "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.1.1.tgz",
+      "integrity": "sha512-Dlq/5LAZgF0Gaz6yiqZCf6VCcZs1ghAJyrsu84Q/GT0gV+mCxbfmKNoGRKBYMJ8IEdGPqu49YWXD02GCknEDkw==",
       "license": "MIT",
       "peer": true,
       "dependencies": {
-        "loose-envify": "^1.1.0",
-        "scheduler": "^0.23.2"
+        "scheduler": "^0.26.0"
       },
       "peerDependencies": {
-        "react": "^18.3.1"
+        "react": "^19.1.1"
       }
     },
     "node_modules/react-is": {
@@ -15265,14 +15308,11 @@
       }
     },
     "node_modules/scheduler": {
-      "version": "0.23.2",
-      "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.23.2.tgz",
-      "integrity": "sha512-UOShsPwz7NrMUqhR6t0hWjFduvOzbtv7toDH1/hIrfRNIDBnnBWd0CwJTGvTpngVlmwGCdP9/Zl/tVrDqcuYzQ==",
+      "version": "0.26.0",
+      "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.26.0.tgz",
+      "integrity": "sha512-NlHwttCI/l5gCPR3D1nNXtWABUmBwvZpEQiD4IXSbIDq8BzLIK/7Ir5gTFSGZDUu37K5cMNp0hFtzO38sC7gWA==",
       "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "loose-envify": "^1.1.0"
-      }
+      "peer": true
     },
     "node_modules/schema-utils": {
       "version": "3.3.0",
@@ -15764,9 +15804,9 @@
       }
     },
     "node_modules/storybook": {
-      "version": "9.1.3",
-      "resolved": "https://registry.npmjs.org/storybook/-/storybook-9.1.3.tgz",
-      "integrity": "sha512-Sm+qP3iGb/QKx/jTYdfE0mIeTmA2HF+5k9fD70S9oOJq3F9UdW8MLgs+5PE+E/xAfDjZU4OWAKEOyA6EYIvQHg==",
+      "version": "9.1.5",
+      "resolved": "https://registry.npmjs.org/storybook/-/storybook-9.1.5.tgz",
+      "integrity": "sha512-cGwJ2AE6nxlwqQlOiI+HKX5qa7+FOV7Ha7Qa+GoASBIQSSnLfbY6UldgAxHCJGJOFtgW/wuqfDtNvni6sj1/OQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -68,10 +68,10 @@
     "xlsx": "^0.18.5"
   },
   "devDependencies": {
-    "@embeddable.com/core": "^2.10.7",
-    "@embeddable.com/react": "^2.10.8",
-    "@embeddable.com/sdk-core": "^4.0.2",
-    "@embeddable.com/sdk-react": "^4.0.2",
+    "@embeddable.com/core": "^2.11.1",
+    "@embeddable.com/react": "^2.11.0",
+    "@embeddable.com/sdk-core": "^4.1.2",
+    "@embeddable.com/sdk-react": "^4.0.6",
     "@eslint/css": "^0.10.0",
     "@eslint/js": "^9.31.0",
     "@storybook/addon-webpack5-compiler-swc": "^3.0.0",
@@ -98,8 +98,8 @@
     "typescript-eslint": "^8.37.0"
   },
   "peerDependencies": {
-    "react": "^18.2.0",
-    "react-dom": "^18.2.0"
+    "react": "18.2.0 || ^19.0.0",
+    "react-dom": "18.2.0 || ^19.0.0"
   },
   "optionalDependencies": {
     "@swc/core-linux-x64-gnu": "^1.13.5"


### PR DESCRIPTION
# Why is this pull-request needed?
This is to use the latest version of the embeddable sdks and enable the remarkable UI npm package to work with react 19. 

# Main changes
* Migrated to latest version of embeddable sdks as they now support react 19.
* Updated the peer dependencies to include react 19 since that's needed for our Frontend repository.

# Test evidence
This is just to confirm that the remarkable-ui components are working as before:

https://github.com/user-attachments/assets/d965a347-dfb4-455b-a3d8-5b58b7f0a496


