### PR TITLE
RUI-82: Add page overlay component

### DIFF
--- a/src/remarkable-ui/index.ts
+++ b/src/remarkable-ui/index.ts
@@ -11,6 +11,8 @@ export {
 } from './editors/select/shared/SelectList/SelectListOptions/SelectListOption/SelectListOption';
 export { SelectListOptions } from './editors/select/shared/SelectList/SelectListOptions/SelectListOptions';
 export { Button } from './shared/Button/Button';
+export { PageOverlay } from './shared/PageOverlay';
+export type { PageOverlayProps } from './shared/PageOverlay';
 export { MultiSelectField } from './editors/select/MultiSelectField/MultiSelectField';
 export { Switch } from './shared/Switch/Switch';
 

--- a/src/remarkable-ui/shared/PageOverlay/PageOverlay.module.css
+++ b/src/remarkable-ui/shared/PageOverlay/PageOverlay.module.css
@@ -1,0 +1,14 @@
+.overlay {
+  position: fixed;
+  top: 0;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  width: 100vw;
+  height: 100vh;
+  background-color: rgba(0, 0, 0, 0.75);
+  z-index: 9999;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}

--- a/src/remarkable-ui/shared/PageOverlay/PageOverlay.stories.tsx
+++ b/src/remarkable-ui/shared/PageOverlay/PageOverlay.stories.tsx
@@ -1,0 +1,125 @@
+import type { Meta, StoryObj } from '@storybook/react-webpack5';
+import { useState } from 'react';
+
+import { PageOverlay } from './PageOverlay';
+import { Button } from '../Button/Button';
+import { Card } from '../Card/Card';
+
+const meta = {
+  component: PageOverlay,
+  parameters: {
+    layout: 'fullscreen',
+  },
+} satisfies Meta<typeof PageOverlay>;
+
+export default meta;
+
+type Story = StoryObj<typeof meta>;
+
+const OverlayWithContent = ({
+  isVisible,
+  onClose,
+}: {
+  isVisible: boolean;
+  onClose: () => void;
+}) => (
+  <PageOverlay isVisible={isVisible}>
+    <Card style={{ padding: '2rem', maxWidth: '400px', margin: '1rem' }}>
+      <h2 style={{ margin: '0 0 1rem 0', color: '#212129' }}>Modal Content</h2>
+      <p style={{ margin: '0 0 1.5rem 0', color: '#5c5c66' }}>
+        This is content inside the overlay. Use the button to close.
+      </p>
+      <Button variant="primary" size="medium" onClick={onClose}>
+        Close Modal
+      </Button>
+    </Card>
+  </PageOverlay>
+);
+
+export const Default: Story = {
+  args: {
+    isVisible: true,
+  },
+  render: () => {
+    const [isVisible, setIsVisible] = useState(false);
+
+    return (
+      <div style={{ padding: '2rem' }}>
+        <h1>Page Overlay Demo</h1>
+        <p>Click the button below to show the overlay:</p>
+        <Button variant="primary" size="medium" onClick={() => setIsVisible(true)}>
+          Show Overlay
+        </Button>
+        <OverlayWithContent isVisible={isVisible} onClose={() => setIsVisible(false)} />
+      </div>
+    );
+  },
+};
+
+export const WithCustomContent: Story = {
+  args: {
+    isVisible: true,
+  },
+  render: () => {
+    const [isVisible, setIsVisible] = useState(false);
+
+    return (
+      <div style={{ padding: '2rem' }}>
+        <h1>Custom Content Overlay</h1>
+        <p>This overlay contains custom content:</p>
+        <Button variant="secondary" size="medium" onClick={() => setIsVisible(true)}>
+          Show Custom Overlay
+        </Button>
+        <PageOverlay isVisible={isVisible}>
+          <div
+            style={{
+              background: 'white',
+              padding: '3rem',
+              borderRadius: '8px',
+              textAlign: 'center',
+              boxShadow: '0 4px 20px rgba(0, 0, 0, 0.15)',
+            }}
+          >
+            <h2 style={{ color: '#212129', marginBottom: '1rem' }}>Custom Modal</h2>
+            <p style={{ color: '#5c5c66', marginBottom: '2rem' }}>
+              This is a custom modal with different styling.
+            </p>
+            <Button variant="primary" size="medium" onClick={() => setIsVisible(false)}>
+              Close
+            </Button>
+          </div>
+        </PageOverlay>
+      </div>
+    );
+  },
+};
+
+export const SimpleOverlay: Story = {
+  args: {
+    isVisible: true,
+  },
+  render: () => {
+    const [isVisible, setIsVisible] = useState(false);
+
+    return (
+      <div style={{ padding: '2rem' }}>
+        <h1>Simple Overlay</h1>
+        <p>This is a simple overlay without click functionality:</p>
+        <Button variant="primary" size="medium" onClick={() => setIsVisible(true)}>
+          Show Simple Overlay
+        </Button>
+        <PageOverlay isVisible={isVisible}>
+          <Card style={{ padding: '2rem', maxWidth: '400px', margin: '1rem' }}>
+            <h2 style={{ margin: '0 0 1rem 0', color: '#212129' }}>Simple Modal</h2>
+            <p style={{ margin: '0 0 1.5rem 0', color: '#5c5c66' }}>
+              This overlay cannot be closed by clicking outside. You must use the button.
+            </p>
+            <Button variant="primary" size="medium" onClick={() => setIsVisible(false)}>
+              Close Modal
+            </Button>
+          </Card>
+        </PageOverlay>
+      </div>
+    );
+  },
+};

--- a/src/remarkable-ui/shared/PageOverlay/PageOverlay.tsx
+++ b/src/remarkable-ui/shared/PageOverlay/PageOverlay.tsx
@@ -1,0 +1,15 @@
+import clsx from 'clsx';
+import styles from './PageOverlay.module.css';
+import type { PageOverlayProps } from './PageOverlay.types';
+
+export const PageOverlay: React.FC<PageOverlayProps> = ({ isVisible, className, children }) => {
+  if (!isVisible) {
+    return null;
+  }
+
+  return (
+    <div className={clsx(styles.overlay, className)} role="dialog" aria-modal="true">
+      {children}
+    </div>
+  );
+};

--- a/src/remarkable-ui/shared/PageOverlay/PageOverlay.types.ts
+++ b/src/remarkable-ui/shared/PageOverlay/PageOverlay.types.ts
@@ -1,0 +1,8 @@
+export type PageOverlayProps = {
+  /** Whether the overlay is visible */
+  isVisible: boolean;
+  /** Additional CSS class name */
+  className?: string;
+  /** Children to render inside the overlay */
+  children?: React.ReactNode;
+};

--- a/src/remarkable-ui/shared/PageOverlay/index.ts
+++ b/src/remarkable-ui/shared/PageOverlay/index.ts
@@ -1,0 +1,2 @@
+export { PageOverlay } from './PageOverlay';
+export type { PageOverlayProps } from './PageOverlay.types';


### PR DESCRIPTION
# Why is this pull-request needed?

We need this Overlay component to use in our modals.

# Main changes
Added the overlay component that fully occupies the page and renders the children provided to it.
# Test evidence


https://github.com/user-attachments/assets/7f8f38a9-88e7-4546-ab9f-abf36d66ffce

