### PR TITLE
RUI-93: chart card bug

### DIFF
--- a/src/remarkable-pro/components/charts/shared/ChartCard/ChartCard.module.css
+++ b/src/remarkable-pro/components/charts/shared/ChartCard/ChartCard.module.css
@@ -1,3 +1,8 @@
+.chartCard {
+  height: 100%;
+  width: 100%;
+}
+
 .error svg,
 .error h2,
 .error p {

--- a/src/remarkable-pro/components/charts/shared/ChartCard/ChartCard.tsx
+++ b/src/remarkable-pro/components/charts/shared/ChartCard/ChartCard.tsx
@@ -71,7 +71,7 @@ export const ChartCard: FC<ChartCardProps> = ({
   };
 
   return (
-    <Card ref={chartRef} {...props}>
+    <Card ref={chartRef} className={styles.chartCard} {...props}>
       <CardHeader
         title={title}
         subtitle={subtitle}


### PR DESCRIPTION
# Why is this pull-request needed?

The charts are displayed inside of a card. 

That card should have a dynamic height and width , so the chart that is presented inside resizes as the user resizes the Card component.

# Main changes

- When the Card component is used for the ChartCard, make sure it has height and width 100%


# Test evidence


https://github.com/user-attachments/assets/c01128e0-d3f5-41d5-9d85-f3e364a8691c


