### PR TITLE
RUI-000: handle the css vars after the buildPackage

### DIFF
--- a/.changeset/famous-clowns-hang.md
+++ b/.changeset/famous-clowns-hang.md
@@ -1,0 +1,5 @@
+---
+'@embeddable.com/remarkable-ui': patch
+---
+
+Add the css variables after build package script

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "access": "public"
   },
   "scripts": {
-    "build": "npm run process:css-variables && tsc",
+    "build": "tsc",
     "process:css-variables": "node scripts/process-css-variables.js",
     "build-storybook": "storybook build",
     "circular:check": "madge --circular .",
@@ -21,7 +21,7 @@
     "embeddable:build": "embeddable build",
     "embeddable:dev": "embeddable dev",
     "embeddable:login": "embeddable login",
-    "embeddable:package": "embeddable buildPackage",
+    "embeddable:package": "embeddable buildPackage && npm run process:css-variables",
     "embeddable:push": "embeddable push",
     "embeddable:upgrade": "npx npm-check-updates -u \"/embeddable/\"",
     "eslint:check": "eslint .",


### PR DESCRIPTION
# Why is this pull-request needed?

This is to handle the css variables before publishing to npm 

# Main changes

* moved the css injection script right after the buildPackage is done
# Test evidence

N/A

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated build and packaging workflow to run CSS variable processing after the package is built, improving consistency of styles in the distributed package.
  * Adjusted scripts to streamline the build process and ensure post-build styling steps happen during packaging.
  * Added a changeset entry to release these adjustments as a patch update.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->