### PR TITLE
RUI-000: hide granularity for dimensionTime

### DIFF
--- a/.changeset/kind-bags-jam.md
+++ b/.changeset/kind-bags-jam.md
@@ -1,0 +1,5 @@
+---
+'@embeddable.com/remarkable-ui': patch
+---
+
+Hide granularity for dimensionTime

--- a/src/remarkable-pro/components/component.constants.ts
+++ b/src/remarkable-pro/components/component.constants.ts
@@ -124,6 +124,7 @@ export const dimensionTime = {
   config: {
     dataset: 'dataset',
     supportedTypes: ['time'],
+    hideGranularity: true,
   },
   required: true,
   category: 'Component Data',


### PR DESCRIPTION


# Main changes

Hide Granularity for timeDimension default

# Test evidence

<img width="990" height="506" alt="image" src="https://github.com/user-attachments/assets/f96129b6-dc81-4e49-8e18-d84b00e70e7c" />
