### PR TITLE
RUI-114: playtomic bugs and improvements

### DIFF
--- a/.changeset/hot-geese-try.md
+++ b/.changeset/hot-geese-try.md
@@ -1,0 +1,5 @@
+---
+'@embeddable.com/remarkable-ui': patch
+---
+
+Fix BarStacked formatting, allow define decimal places for percentage kpi changes

--- a/src/remarkable-pro/components/charts/bars/bars.utils.ts
+++ b/src/remarkable-pro/components/charts/bars/bars.utils.ts
@@ -131,7 +131,7 @@ const getBarChartProDatalabelTotalFormatter = (
     return sum + (val || 0);
   }, 0);
 
-  return total > 0 ? formatter(total) : null;
+  return formatter(total);
 };
 
 export const getBarChartProOptions = (

--- a/src/remarkable-pro/components/charts/bars/bars.utils.ts
+++ b/src/remarkable-pro/components/charts/bars/bars.utils.ts
@@ -9,6 +9,7 @@ import { getColor } from '../../../theme/styles/styles.utils';
 import { chartColors } from '../../../../remarkable-ui';
 import { getObjectStableKey } from '../../../utils.ts/object.utils';
 import { chartContrastColors } from '../../../../remarkable-ui/charts/charts.constants';
+import { Context } from 'chartjs-plugin-datalabels';
 
 export const getBarStackedChartProData = (
   props: {
@@ -118,6 +119,21 @@ export const getBarChartProData = (
   };
 };
 
+const getBarChartProDatalabelTotalFormatter = (
+  context: Context,
+  formatter: (value: number) => string,
+) => {
+  const { datasets } = context.chart.data;
+  const i = context.dataIndex;
+
+  const total = datasets.reduce((sum, ds) => {
+    const val = ds.data[i] as number;
+    return sum + (val || 0);
+  }, 0);
+
+  return total > 0 ? formatter(total) : null;
+};
+
 export const getBarChartProOptions = (
   options: {
     onBarClicked: (args: {
@@ -136,7 +152,17 @@ export const getBarChartProOptions = (
     plugins: {
       legend: { position: theme.charts.legendPosition ?? 'bottom' },
       datalabels: {
-        formatter: (value: string | number) => themeFormatter.data(options.measure, value),
+        labels: {
+          total: {
+            formatter: (_value: string | number, context: Context) =>
+              getBarChartProDatalabelTotalFormatter(context, (value: number) =>
+                themeFormatter.data(options.measure, value),
+              ),
+          },
+          value: {
+            formatter: (value: string | number) => themeFormatter.data(options.measure, value),
+          },
+        },
       },
       tooltip: {
         callbacks: {

--- a/src/remarkable-pro/components/charts/kpis/KpiChartNumberComparisonPro/KpiChartNumberComparisonPro.emb.ts
+++ b/src/remarkable-pro/components/charts/kpis/KpiChartNumberComparisonPro/KpiChartNumberComparisonPro.emb.ts
@@ -44,6 +44,12 @@ export const meta = {
       defaultValue: false,
     },
     {
+      ...genericNumber,
+      name: 'percentageDecimalPlaces',
+      label: 'Percentage Decimal Places',
+      defaultValue: 1,
+    },
+    {
       ...genericBoolean,
       name: 'reversePositiveNegativeColors',
       label: 'Reverse Positive/Negative Colors',
@@ -56,12 +62,6 @@ export const meta = {
       label: 'Change Font Size',
       defaultValue: 16,
       required: true,
-    },
-    {
-      ...genericNumber,
-      name: 'percentageDecimalPlaces',
-      label: 'Percentage Decimal Places',
-      defaultValue: 1,
     },
   ],
 } as const satisfies EmbeddedComponentMeta;

--- a/src/remarkable-pro/components/charts/kpis/KpiChartNumberComparisonPro/KpiChartNumberComparisonPro.emb.ts
+++ b/src/remarkable-pro/components/charts/kpis/KpiChartNumberComparisonPro/KpiChartNumberComparisonPro.emb.ts
@@ -57,6 +57,12 @@ export const meta = {
       defaultValue: 16,
       required: true,
     },
+    {
+      ...genericNumber,
+      name: 'percentageDecimalPlaces',
+      label: 'Percentage Decimal Places',
+      defaultValue: 1,
+    },
   ],
 } as const satisfies EmbeddedComponentMeta;
 

--- a/src/remarkable-pro/components/charts/kpis/KpiChartNumberComparisonPro/index.tsx
+++ b/src/remarkable-pro/components/charts/kpis/KpiChartNumberComparisonPro/index.tsx
@@ -24,6 +24,7 @@ type KpiChartNumberComparisonProProp = {
   resultsComparison: DataResponse | undefined;
   reversePositiveNegativeColors?: boolean;
   title: string;
+  percentageDecimalPlaces: number;
   comparisonDateRange: TimeRange;
   setComparisonDateRange: (dateRange: TimeRange) => void;
 };
@@ -44,6 +45,7 @@ const KpiChartNumberComparisonPro = (props: KpiChartNumberComparisonProProp) => 
     results,
     resultsComparison,
     reversePositiveNegativeColors,
+    percentageDecimalPlaces,
     setComparisonDateRange,
   } = props;
 
@@ -82,6 +84,7 @@ const KpiChartNumberComparisonPro = (props: KpiChartNumberComparisonProProp) => 
         invertChangeColors={reversePositiveNegativeColors}
         showChangeAsPercentage={displayChangeAsPercentage}
         comparisonLabel={comparisonLabel}
+        percentageDecimalPlaces={percentageDecimalPlaces}
       />
     </ChartCard>
   );

--- a/src/remarkable-pro/components/types/ComparisonPeriod.type.emb.ts
+++ b/src/remarkable-pro/components/types/ComparisonPeriod.type.emb.ts
@@ -5,7 +5,6 @@ const ComparisonPeriodType = defineType('comparisonPeriod', {
   optionLabel: (value: string) => value,
 });
 
-defineOption(ComparisonPeriodType, 'summer');
 defineOption(ComparisonPeriodType, 'Previous period');
 defineOption(ComparisonPeriodType, 'Previous week');
 defineOption(ComparisonPeriodType, 'Previous month');

--- a/src/remarkable-pro/theme/formatter/formatter.constants.ts
+++ b/src/remarkable-pro/theme/formatter/formatter.constants.ts
@@ -64,7 +64,7 @@ const dataNumberFormatter = (theme: Theme, key: DimensionOrMeasure): NumberForma
     style: currency ? 'currency' : undefined,
     currency: currency ? currency : undefined,
     notation: key.inputs?.abbreviateLargeNumber ? 'compact' : undefined,
-    maximumFractionDigits: key.inputs?.decimalPlaces ?? undefined,
+    maximumFractionDigits: currency ? (key.inputs?.decimalPlaces ?? 0) : undefined,
   };
 
   return theme.formatter.numberFormatter(theme, options);

--- a/src/remarkable-pro/theme/formatter/formatter.constants.ts
+++ b/src/remarkable-pro/theme/formatter/formatter.constants.ts
@@ -64,7 +64,7 @@ const dataNumberFormatter = (theme: Theme, key: DimensionOrMeasure): NumberForma
     style: currency ? 'currency' : undefined,
     currency: currency ? currency : undefined,
     notation: key.inputs?.abbreviateLargeNumber ? 'compact' : undefined,
-    maximumFractionDigits: key.inputs?.decimalPlaces ?? 0,
+    maximumFractionDigits: key.inputs?.decimalPlaces ?? undefined,
   };
 
   return theme.formatter.numberFormatter(theme, options);

--- a/src/remarkable-ui/charts/kpis/KpiChart.tsx
+++ b/src/remarkable-ui/charts/kpis/KpiChart.tsx
@@ -12,6 +12,7 @@ export const KpiChart: FC<KpiChartProps> = ({
   comparisonLabel,
   invertChangeColors,
   showChangeAsPercentage,
+  percentageDecimalPlaces = 1,
   equalComparisonLabel = 'No change',
   valueFontSize,
   valueFormatter,
@@ -29,14 +30,15 @@ export const KpiChart: FC<KpiChartProps> = ({
           <Typography>{equalComparisonLabel}</Typography>
         ) : (
           <KpiChartChange
+            changeFontSize={changeFontSize}
             className={clsx(!hasComparisonValue && styles.kpiChangeHidden)}
-            value={value}
-            valueFormatter={valueFormatter}
+            comparisonLabel={comparisonLabel}
             comparisonValue={comparisonValue}
             invertChangeColors={invertChangeColors}
+            percentageDecimalPlaces={percentageDecimalPlaces}
             showChangeAsPercentage={showChangeAsPercentage}
-            comparisonLabel={comparisonLabel}
-            changeFontSize={changeFontSize}
+            value={value}
+            valueFormatter={valueFormatter}
           />
         )}
       </div>

--- a/src/remarkable-ui/charts/kpis/KpiChart.tsx
+++ b/src/remarkable-ui/charts/kpis/KpiChart.tsx
@@ -31,6 +31,7 @@ export const KpiChart: FC<KpiChartProps> = ({
           <KpiChartChange
             className={clsx(!hasComparisonValue && styles.kpiChangeHidden)}
             value={value}
+            valueFormatter={valueFormatter}
             comparisonValue={comparisonValue}
             invertChangeColors={invertChangeColors}
             showChangeAsPercentage={showChangeAsPercentage}

--- a/src/remarkable-ui/charts/kpis/KpiChart.types.ts
+++ b/src/remarkable-ui/charts/kpis/KpiChart.types.ts
@@ -8,6 +8,7 @@ export type KpiChartProps = {
   invertChangeColors?: boolean;
   comparisonLabel?: string;
   equalComparisonLabel?: string;
+  percentageDecimalPlaces?: number;
   valueFontSize?: CssSize;
   valueFormatter?: (value: number) => string;
 };

--- a/src/remarkable-ui/charts/kpis/components/KpiChartChange.tsx
+++ b/src/remarkable-ui/charts/kpis/components/KpiChartChange.tsx
@@ -19,6 +19,7 @@ export const KpiChartChange: FC<KpiChartChangeProps> = ({
   invertChangeColors = false,
   comparisonLabel,
   valueFormatter,
+  percentageDecimalPlaces = 1,
   className,
 }) => {
   const difference = value - comparisonValue;
@@ -28,9 +29,7 @@ export const KpiChartChange: FC<KpiChartChangeProps> = ({
 
   if (showChangeAsPercentage) {
     const percentage = comparisonValue === 0 ? 0 : (difference / comparisonValue) * 100;
-    const percentageDisplay = percentage.toFixed(1);
-
-    differenceLabel = `${percentageDisplay}%`;
+    differenceLabel = `${percentage.toFixed(percentageDecimalPlaces)}%`;
   } else {
     differenceLabel = valueFormatter ? valueFormatter(difference) : difference.toString();
   }

--- a/src/remarkable-ui/charts/kpis/components/KpiChartChange.tsx
+++ b/src/remarkable-ui/charts/kpis/components/KpiChartChange.tsx
@@ -18,20 +18,21 @@ export const KpiChartChange: FC<KpiChartChangeProps> = ({
   showChangeAsPercentage,
   invertChangeColors = false,
   comparisonLabel,
+  valueFormatter,
   className,
 }) => {
   const difference = value - comparisonValue;
   const isPositive = difference > 0;
 
-  let differenceLabel: string = difference.toString();
+  let differenceLabel: string;
 
   if (showChangeAsPercentage) {
     const percentage = comparisonValue === 0 ? 0 : (difference / comparisonValue) * 100;
-
-    const percentageDisplay =
-      percentage % 1 === 0 ? percentage : percentage.toFixed(1).replace(/\.?0+$/, '');
+    const percentageDisplay = percentage.toFixed(1);
 
     differenceLabel = `${percentageDisplay}%`;
+  } else {
+    differenceLabel = valueFormatter ? valueFormatter(difference) : difference.toString();
   }
 
   const displayValue = `${isPositive ? '+' : ''}${differenceLabel}`;


### PR DESCRIPTION
# Why is this pull-request needed?

This PR includes improvements and bug fixes reported by Playtomic.


# Test evidence

Show zeros on total values:

<img width="676" height="714" alt="image" src="https://github.com/user-attachments/assets/7a52aae2-84ca-4ac8-b0d5-fd1611eb62ac" />



Format totals:

<img width="659" height="763" alt="image" src="https://github.com/user-attachments/assets/ea905bd2-5dab-491e-9fd8-4b218c95fe85" />

Show default number formatting if there is no decimal places set:

<img width="651" height="720" alt="image" src="https://github.com/user-attachments/assets/6c8c7a49-1c2e-4310-9967-df9b0bc64b8e" />

New input to define the percentage decimal places:


https://github.com/user-attachments/assets/c6de0fca-0c07-4d8a-9483-233707f16119



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Bar charts now display dual data labels: a total per category alongside individual bar values.
  * Totals appear only when greater than zero, reducing visual clutter.
  * Improved readability for stacked or grouped bars, enabling quicker at-a-glance comparisons.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->