### PR TITLE
RUI-252: filter non-integer Y-axis ticks via afterBuildTicks

### DIFF
--- a/.changeset/tender-ravens-look.md
+++ b/.changeset/tender-ravens-look.md
@@ -1,0 +1,5 @@
+---
+'@embeddable.com/remarkable-ui': patch
+---
+
+Improve ticks on chartjs cartesian charts

--- a/src/components/charts/chartjs.cartesian.constants.test.ts
+++ b/src/components/charts/chartjs.cartesian.constants.test.ts
@@ -1,0 +1,76 @@
+import { describe, expect, it } from 'vitest';
+import { getChartjsAxisOptionsScales } from './chartjs.cartesian.constants';
+
+describe('getChartjsAxisOptionsScales', () => {
+  describe('y scale afterBuildTicks', () => {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const getAfterBuildTicks = (): ((scale: any) => void) => {
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      const scales = getChartjsAxisOptionsScales() as any;
+      // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-explicit-any
+      return scales.y.afterBuildTicks as (scale: any) => void;
+    };
+
+    const makeMockScale = (datasets: { data: number[] }[], ticks: { value: number }[]) => ({
+      chart: { data: { datasets } },
+      ticks: [...ticks],
+    });
+
+    it('filters out non-integer ticks when all data values are integers', () => {
+      const afterBuildTicks = getAfterBuildTicks();
+      const scale = makeMockScale(
+        [{ data: [1, 2, 3] }],
+        [
+          { value: 0 },
+          { value: 0.5 },
+          { value: 1 },
+          { value: 1.5 },
+          { value: 2 },
+          { value: 2.5 },
+          { value: 3 },
+        ],
+      );
+      afterBuildTicks(scale);
+      expect(scale.ticks.every((t) => Number.isInteger(t.value))).toBe(true);
+    });
+
+    it('leaves ticks unchanged when data contains decimal values', () => {
+      const afterBuildTicks = getAfterBuildTicks();
+      const scale = makeMockScale(
+        [{ data: [1.5, 2.5] }],
+        [{ value: 0 }, { value: 0.5 }, { value: 1 }, { value: 1.5 }, { value: 2 }, { value: 2.5 }],
+      );
+      const originalTicks = [...scale.ticks];
+      afterBuildTicks(scale);
+      expect(scale.ticks).toEqual(originalTicks);
+    });
+
+    it('leaves ticks unchanged when datasets are empty', () => {
+      const afterBuildTicks = getAfterBuildTicks();
+      const scale = makeMockScale([], [{ value: 0 }, { value: 0.5 }, { value: 1 }]);
+      const originalTicks = [...scale.ticks];
+      afterBuildTicks(scale);
+      expect(scale.ticks).toEqual(originalTicks);
+    });
+
+    it('filters non-integer ticks for large integer ranges (no threshold)', () => {
+      const afterBuildTicks = getAfterBuildTicks();
+      const scale = makeMockScale(
+        [{ data: [10, 20, 30] }],
+        [{ value: 0 }, { value: 3.33 }, { value: 10 }, { value: 20 }, { value: 30 }],
+      );
+      afterBuildTicks(scale);
+      expect(scale.ticks.every((t) => Number.isInteger(t.value))).toBe(true);
+    });
+
+    it('handles multiple datasets correctly', () => {
+      const afterBuildTicks = getAfterBuildTicks();
+      const scale = makeMockScale(
+        [{ data: [1, 2] }, { data: [3, 4] }],
+        [{ value: 0 }, { value: 0.5 }, { value: 1 }, { value: 2 }, { value: 3 }, { value: 4 }],
+      );
+      afterBuildTicks(scale);
+      expect(scale.ticks.every((t) => Number.isInteger(t.value))).toBe(true);
+    });
+  });
+});

--- a/src/components/charts/chartjs.cartesian.constants.test.ts
+++ b/src/components/charts/chartjs.cartesian.constants.test.ts
@@ -31,7 +31,7 @@ describe('getChartjsAxisOptionsScales', () => {
         ],
       );
       afterBuildTicks(scale);
-      expect(scale.ticks.every((t) => Number.isInteger(t.value))).toBe(true);
+      expect(scale.ticks).toEqual([{ value: 0 }, { value: 1 }, { value: 2 }, { value: 3 }]);
     });
 
     it('leaves ticks unchanged when data contains decimal values', () => {
@@ -60,7 +60,7 @@ describe('getChartjsAxisOptionsScales', () => {
         [{ value: 0 }, { value: 3.33 }, { value: 10 }, { value: 20 }, { value: 30 }],
       );
       afterBuildTicks(scale);
-      expect(scale.ticks.every((t) => Number.isInteger(t.value))).toBe(true);
+      expect(scale.ticks).toEqual([{ value: 0 }, { value: 10 }, { value: 20 }, { value: 30 }]);
     });
 
     it('handles multiple datasets correctly', () => {
@@ -70,7 +70,13 @@ describe('getChartjsAxisOptionsScales', () => {
         [{ value: 0 }, { value: 0.5 }, { value: 1 }, { value: 2 }, { value: 3 }, { value: 4 }],
       );
       afterBuildTicks(scale);
-      expect(scale.ticks.every((t) => Number.isInteger(t.value))).toBe(true);
+      expect(scale.ticks).toEqual([
+        { value: 0 },
+        { value: 1 },
+        { value: 2 },
+        { value: 3 },
+        { value: 4 },
+      ]);
     });
   });
 
@@ -95,7 +101,7 @@ describe('getChartjsAxisOptionsScales', () => {
         ],
       );
       afterBuildTicks(scale);
-      expect(scale.ticks.every((t) => Number.isInteger(t.value))).toBe(true);
+      expect(scale.ticks).toEqual([{ value: 0 }, { value: 1 }, { value: 2 }, { value: 3 }]);
     });
 
     it('leaves ticks unchanged when data contains decimal values', () => {

--- a/src/components/charts/chartjs.cartesian.constants.test.ts
+++ b/src/components/charts/chartjs.cartesian.constants.test.ts
@@ -2,19 +2,19 @@ import { describe, expect, it } from 'vitest';
 import { getChartjsAxisOptionsScales } from './chartjs.cartesian.constants';
 
 describe('getChartjsAxisOptionsScales', () => {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const scales = getChartjsAxisOptionsScales() as any;
+
+  const makeMockScale = (datasets: { data: number[] }[], ticks: { value: number }[]) => ({
+    chart: { data: { datasets } },
+    ticks: [...ticks],
+  });
+
   describe('y scale afterBuildTicks', () => {
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    const getAfterBuildTicks = (): ((scale: any) => void) => {
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      const scales = getChartjsAxisOptionsScales() as any;
+    const getAfterBuildTicks = (): ((scale: any) => void) =>
       // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-explicit-any
-      return scales.y.afterBuildTicks as (scale: any) => void;
-    };
-
-    const makeMockScale = (datasets: { data: number[] }[], ticks: { value: number }[]) => ({
-      chart: { data: { datasets } },
-      ticks: [...ticks],
-    });
+      scales.y.afterBuildTicks as (scale: any) => void;
 
     it('filters out non-integer ticks when all data values are integers', () => {
       const afterBuildTicks = getAfterBuildTicks();
@@ -71,6 +71,50 @@ describe('getChartjsAxisOptionsScales', () => {
       );
       afterBuildTicks(scale);
       expect(scale.ticks.every((t) => Number.isInteger(t.value))).toBe(true);
+    });
+  });
+
+  describe('x scale afterBuildTicks', () => {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const getAfterBuildTicks = (): ((scale: any) => void) =>
+      // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-explicit-any
+      scales.x.afterBuildTicks as (scale: any) => void;
+
+    it('filters out non-integer ticks when all data values are integers', () => {
+      const afterBuildTicks = getAfterBuildTicks();
+      const scale = makeMockScale(
+        [{ data: [1, 2, 3] }],
+        [
+          { value: 0 },
+          { value: 0.5 },
+          { value: 1 },
+          { value: 1.5 },
+          { value: 2 },
+          { value: 2.5 },
+          { value: 3 },
+        ],
+      );
+      afterBuildTicks(scale);
+      expect(scale.ticks.every((t) => Number.isInteger(t.value))).toBe(true);
+    });
+
+    it('leaves ticks unchanged when data contains decimal values', () => {
+      const afterBuildTicks = getAfterBuildTicks();
+      const scale = makeMockScale(
+        [{ data: [1.5, 2.5] }],
+        [{ value: 0 }, { value: 0.5 }, { value: 1 }, { value: 1.5 }, { value: 2 }, { value: 2.5 }],
+      );
+      const originalTicks = [...scale.ticks];
+      afterBuildTicks(scale);
+      expect(scale.ticks).toEqual(originalTicks);
+    });
+
+    it('leaves ticks unchanged when datasets are empty', () => {
+      const afterBuildTicks = getAfterBuildTicks();
+      const scale = makeMockScale([], [{ value: 0 }, { value: 0.5 }, { value: 1 }]);
+      const originalTicks = [...scale.ticks];
+      afterBuildTicks(scale);
+      expect(scale.ticks).toEqual(originalTicks);
     });
   });
 });

--- a/src/components/charts/chartjs.cartesian.constants.ts
+++ b/src/components/charts/chartjs.cartesian.constants.ts
@@ -66,13 +66,13 @@ export const getChartjsAxisOptionsScalesGrid = (): Partial<GridLineOptions> => (
 });
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
-function filterIntegerTicks(scale: any): void {
+const filterIntegerTicks = (scale: any): void => {
   const allValues = (scale.chart.data.datasets as { data: unknown[] }[])
     .flatMap((ds) => ds.data)
     .filter((v): v is number => typeof v === 'number');
   if (!allValues.length || !allValues.every((v) => Number.isInteger(v))) return;
   scale.ticks = scale.ticks.filter((tick: { value: number }) => Number.isInteger(tick.value));
-}
+};
 
 export const getChartjsAxisOptionsScales = (): Partial<ChartOptions['scales']> => ({
   x: {

--- a/src/components/charts/chartjs.cartesian.constants.ts
+++ b/src/components/charts/chartjs.cartesian.constants.ts
@@ -70,6 +70,14 @@ export const getChartjsAxisOptionsScales = (): Partial<ChartOptions['scales']> =
     grid: getChartjsAxisOptionsScalesGrid(),
     title: getChartjsAxisOptionsScalesTitle(),
     ticks: getChartjsAxisOptionsScalesTicksDefault(),
+    afterBuildTicks(scale) {
+      const allValues = scale.chart.data.datasets
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        .flatMap((ds: any) => ds.data as number[])
+        .filter((v: unknown): v is number => typeof v === 'number');
+      if (!allValues.length || !allValues.every((v) => Number.isInteger(v))) return;
+      scale.ticks = scale.ticks.filter((tick) => Number.isInteger(tick.value));
+    },
   },
   y: {
     grid: getChartjsAxisOptionsScalesGrid(),

--- a/src/components/charts/chartjs.cartesian.constants.ts
+++ b/src/components/charts/chartjs.cartesian.constants.ts
@@ -1,4 +1,4 @@
-import { CartesianTickOptions, ChartOptions, GridLineOptions } from 'chart.js';
+import { CartesianTickOptions, ChartOptions, GridLineOptions, Scale } from 'chart.js';
 import { getStyle, getStyleNumber } from '../../styles/styles.utils';
 import { mergician } from 'mergician';
 import { getChartjsOptions } from './chartjs.constants';
@@ -65,8 +65,7 @@ export const getChartjsAxisOptionsScalesGrid = (): Partial<GridLineOptions> => (
   lineWidth: getStyleNumber('--em-chart-grid-line-width--thin', '0.0625rem'),
 });
 
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
-const filterIntegerTicks = (scale: any): void => {
+const filterIntegerTicks = (scale: Scale): void => {
   const allValues = (scale.chart.data.datasets as { data: unknown[] }[])
     .flatMap((ds) => ds.data)
     .filter((v): v is number => typeof v === 'number');

--- a/src/components/charts/chartjs.cartesian.constants.ts
+++ b/src/components/charts/chartjs.cartesian.constants.ts
@@ -75,6 +75,14 @@ export const getChartjsAxisOptionsScales = (): Partial<ChartOptions['scales']> =
     grid: getChartjsAxisOptionsScalesGrid(),
     title: getChartjsAxisOptionsScalesTitle(),
     ticks: getChartjsAxisOptionsScalesTicksMuted(),
+    afterBuildTicks(scale) {
+      const allValues = scale.chart.data.datasets
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        .flatMap((ds: any) => ds.data as number[])
+        .filter((v: unknown): v is number => typeof v === 'number');
+      if (!allValues.length || !allValues.every((v) => Number.isInteger(v))) return;
+      scale.ticks = scale.ticks.filter((tick) => Number.isInteger(tick.value));
+    },
   },
 });
 

--- a/src/components/charts/chartjs.cartesian.constants.ts
+++ b/src/components/charts/chartjs.cartesian.constants.ts
@@ -65,7 +65,7 @@ export const getChartjsAxisOptionsScalesGrid = (): Partial<GridLineOptions> => (
   lineWidth: getStyleNumber('--em-chart-grid-line-width--thin', '0.0625rem'),
 });
 
-const filterIntegerTicks = (scale: Scale): void => {
+const afterBuildTicks = (scale: Scale): void => {
   const allValues = (scale.chart.data.datasets as { data: unknown[] }[])
     .flatMap((ds) => ds.data)
     .filter((v): v is number => typeof v === 'number');
@@ -78,13 +78,13 @@ export const getChartjsAxisOptionsScales = (): Partial<ChartOptions['scales']> =
     grid: getChartjsAxisOptionsScalesGrid(),
     title: getChartjsAxisOptionsScalesTitle(),
     ticks: getChartjsAxisOptionsScalesTicksDefault(),
-    afterBuildTicks: filterIntegerTicks,
+    afterBuildTicks,
   },
   y: {
     grid: getChartjsAxisOptionsScalesGrid(),
     title: getChartjsAxisOptionsScalesTitle(),
     ticks: getChartjsAxisOptionsScalesTicksMuted(),
-    afterBuildTicks: filterIntegerTicks,
+    afterBuildTicks,
   },
 });
 

--- a/src/components/charts/chartjs.cartesian.constants.ts
+++ b/src/components/charts/chartjs.cartesian.constants.ts
@@ -65,32 +65,27 @@ export const getChartjsAxisOptionsScalesGrid = (): Partial<GridLineOptions> => (
   lineWidth: getStyleNumber('--em-chart-grid-line-width--thin', '0.0625rem'),
 });
 
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+function filterIntegerTicks(scale: any): void {
+  const allValues = (scale.chart.data.datasets as { data: unknown[] }[])
+    .flatMap((ds) => ds.data)
+    .filter((v): v is number => typeof v === 'number');
+  if (!allValues.length || !allValues.every((v) => Number.isInteger(v))) return;
+  scale.ticks = scale.ticks.filter((tick: { value: number }) => Number.isInteger(tick.value));
+}
+
 export const getChartjsAxisOptionsScales = (): Partial<ChartOptions['scales']> => ({
   x: {
     grid: getChartjsAxisOptionsScalesGrid(),
     title: getChartjsAxisOptionsScalesTitle(),
     ticks: getChartjsAxisOptionsScalesTicksDefault(),
-    afterBuildTicks(scale) {
-      const allValues = scale.chart.data.datasets
-        // eslint-disable-next-line @typescript-eslint/no-explicit-any
-        .flatMap((ds: any) => ds.data as number[])
-        .filter((v: unknown): v is number => typeof v === 'number');
-      if (!allValues.length || !allValues.every((v) => Number.isInteger(v))) return;
-      scale.ticks = scale.ticks.filter((tick) => Number.isInteger(tick.value));
-    },
+    afterBuildTicks: filterIntegerTicks,
   },
   y: {
     grid: getChartjsAxisOptionsScalesGrid(),
     title: getChartjsAxisOptionsScalesTitle(),
     ticks: getChartjsAxisOptionsScalesTicksMuted(),
-    afterBuildTicks(scale) {
-      const allValues = scale.chart.data.datasets
-        // eslint-disable-next-line @typescript-eslint/no-explicit-any
-        .flatMap((ds: any) => ds.data as number[])
-        .filter((v: unknown): v is number => typeof v === 'number');
-      if (!allValues.length || !allValues.every((v) => Number.isInteger(v))) return;
-      scale.ticks = scale.ticks.filter((tick) => Number.isInteger(tick.value));
-    },
+    afterBuildTicks: filterIntegerTicks,
   },
 });
 


### PR DESCRIPTION


# Why is this pull-request needed?

This PR sorts the display of decimal ticks if there are no decimal values. 

# Main changes

- create afterBuildTicks. that checks if all the results are integer or not.
- if all are integer: show integer ticks
- if not all are integer: let charjs decide on how to display the ticks

# Test evidence

<img width="1079" height="745" alt="image" src="https://github.com/user-attachments/assets/124f6a0b-5b95-4c75-b7db-ceb86b567249" />

https://app.us.embeddable.com/en/workspace/3bdc145b-6518-4e29-91a4-b3d8c9051143/builder/9c489b15-863e-45dd-82ab-c914cf6c35be?securityContext=All+artists&componentVersion=344db41a-c5bc-4e2c-9572-d681c99e9236


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Y-axis tick display now automatically adapts based on dataset values—showing only integer ticks when all data values are integers, while preserving decimal ticks for decimal datasets.

* **Tests**
  * Added comprehensive test suite validating y-axis tick behavior across various data scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->