### PR TITLE
[RUI-265]: Add missing export for KpiTrend

### DIFF
--- a/.changeset/silent-tips-exist.md
+++ b/.changeset/silent-tips-exist.md
@@ -1,0 +1,5 @@
+---
+'@embeddable.com/remarkable-ui': patch
+---
+
+Add missing export for KpiTrend

--- a/src/index.ts
+++ b/src/index.ts
@@ -49,6 +49,7 @@ export * from './hooks/useDebounce.hook';
 export * from './hooks/useResizeObserver.hook';
 
 // Shared
+export * from './components/shared/KpiTrend/KpiTrend';
 export * from './components/shared/ActionIcon/ActionIcon';
 export * from './components/shared/Button/Button';
 export * from './components/shared/ButtonIcon/ButtonIcon';


### PR DESCRIPTION
# Why is this pull-request needed?
Add missing export for KpiTrend


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * KpiTrend component is now exported and available for use.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->