### PR TITLE
[RUI-272]: Fix NaN displayed when value is null

### DIFF
--- a/.changeset/chatty-regions-dance.md
+++ b/.changeset/chatty-regions-dance.md
@@ -1,0 +1,5 @@
+---
+'@embeddable.com/remarkable-ui': patch
+---
+
+Fix KpiChart to not show NaN when value is null

--- a/src/components/charts/kpis/KpiChart.test.tsx
+++ b/src/components/charts/kpis/KpiChart.test.tsx
@@ -131,5 +131,34 @@ describe('KpiChart', () => {
 
       expect(comparisonContainer).toBeFalsy();
     });
+
+    it('does not render the comparison section when value is null, even if comparisonValue is provided', () => {
+      const { container } = render(
+        <KpiChart value={null as unknown as number} comparisonValue={80} />,
+      );
+
+      expect(container.querySelector('.kpiComparisonContainer')).toBeFalsy();
+    });
+
+    it('does not render the comparison section when value is null and comparisonValue is 0', () => {
+      const { container } = render(
+        <KpiChart value={null as unknown as number} comparisonValue={0} showChangeAsPercentage />,
+      );
+
+      expect(container.querySelector('.kpiComparisonContainer')).toBeFalsy();
+    });
+
+    it('does not render NaN when value is null and comparisonValue is 0', () => {
+      const { container } = render(
+        <KpiChart
+          value={null as unknown as number}
+          comparisonValue={0}
+          showChangeAsPercentage
+          valueFormatter={(v) => `$${v}`}
+        />,
+      );
+
+      expect(container.textContent).not.toContain('NaN');
+    });
   });
 });

--- a/src/components/charts/kpis/KpiChart.tsx
+++ b/src/components/charts/kpis/KpiChart.tsx
@@ -41,7 +41,7 @@ export const KpiChart: FC<KpiChartProps> = ({
   displayNullAs = '',
   valueFormatter,
 }) => {
-  const hasComparisonValue = comparisonValue !== undefined;
+  const hasComparisonValue = comparisonValue !== undefined && value != null;
 
   const displayValue = getKpiDisplayValue({ value, displayNullAs, valueFormatter });
 


### PR DESCRIPTION
# Why is this pull-request needed?
We need to fix issue when the current or previous value is 0 in comparison KPI charts, the comparison value is NaN

# Main changes
Extended check to not show component when value is null (not only undefined like before)

# Test evidence

https://github.com/user-attachments/assets/d4fc7d45-a804-4303-8297-00ebf0d2e5cd




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes
* Fixed comparison section in KPI charts to only render when both primary and comparison values are properly available
* Resolved edge case preventing incorrect "NaN" values from displaying in component output

<!-- end of auto-generated comment: release notes by coderabbit.ai -->