### PR TITLE
EM-3037: Fix tooltip alignment near right edge

### DIFF
--- a/.changeset/floppy-toes-sing.md
+++ b/.changeset/floppy-toes-sing.md
@@ -1,0 +1,5 @@
+---
+'@embeddable.com/remarkable-ui': patch
+---
+
+Update the tooltip placement

--- a/src/components/shared/Card/Card.stories.tsx
+++ b/src/components/shared/Card/Card.stories.tsx
@@ -24,6 +24,34 @@ export const WithTooltip = () => (
   </Card>
 );
 
+export const WithLongTooltip = () => (
+  <Card>
+    <CardHeader
+      title="Title"
+      subtitle="Subtitle"
+      tooltip="This longer tooltip should align to the end of the info icon so it expands away from right-edge scrollbars."
+    />
+    <CardContent>This is the content of the card.</CardContent>
+  </Card>
+);
+
+export const RightEdgeLongTooltip = () => (
+  <div style={{ display: 'flex', justifyContent: 'flex-end' }}>
+    <div style={{ width: 300 }}>
+      <Card>
+        <CardHeader
+          title="Right edge card"
+          subtitle="Hover the info icon"
+          tooltip="This longer tooltip should stay readable when the card is close to the right edge of the viewport."
+        />
+        <CardContent>
+          This story demonstrates long tooltip alignment near the right edge.
+        </CardContent>
+      </Card>
+    </div>
+  </div>
+);
+
 export const LongTitle = () => (
   <div style={{ maxWidth: 300 }}>
     <Card>

--- a/src/components/shared/Card/Card.test.tsx
+++ b/src/components/shared/Card/Card.test.tsx
@@ -72,6 +72,17 @@ describe('CardHeader', () => {
       expect(tooltip.closest('[data-align]')).toHaveAttribute('data-align', 'end');
     });
 
+    it('aligns long React element tooltips end', async () => {
+      const user = userEvent.setup();
+
+      render(<CardHeader tooltip={<span>Tooltip content.</span>} />);
+
+      await user.hover(screen.getByRole('button', { name: 'Info' }));
+
+      const tooltip = await screen.findByRole('tooltip');
+      expect(tooltip.closest('[data-align]')).toHaveAttribute('data-align', 'end');
+    });
+
     it('returns null when no title, subtitle, or tooltip is provided', () => {
       const { container } = render(<CardHeader />);
 

--- a/src/components/shared/Card/Card.test.tsx
+++ b/src/components/shared/Card/Card.test.tsx
@@ -1,4 +1,5 @@
 import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
 import { createRef } from 'react';
 import { describe, expect, it } from 'vitest';
 import { Card, CardContent, CardHeader } from './Card';
@@ -47,6 +48,28 @@ describe('CardHeader', () => {
       render(<CardHeader tooltip="Tooltip content" />);
 
       expect(screen.getByRole('button', { name: 'Info' })).toBeInTheDocument();
+    });
+
+    it('keeps info tooltips up to 15 characters centered', async () => {
+      const user = userEvent.setup();
+
+      render(<CardHeader tooltip="Tooltip content" />);
+
+      await user.hover(screen.getByRole('button', { name: 'Info' }));
+
+      const tooltip = await screen.findByRole('tooltip');
+      expect(tooltip.closest('[data-align]')).toHaveAttribute('data-align', 'center');
+    });
+
+    it('aligns info tooltips longer than 15 characters end', async () => {
+      const user = userEvent.setup();
+
+      render(<CardHeader tooltip="Tooltip content." />);
+
+      await user.hover(screen.getByRole('button', { name: 'Info' }));
+
+      const tooltip = await screen.findByRole('tooltip');
+      expect(tooltip.closest('[data-align]')).toHaveAttribute('data-align', 'end');
     });
 
     it('returns null when no title, subtitle, or tooltip is provided', () => {

--- a/src/components/shared/Card/Card.test.tsx
+++ b/src/components/shared/Card/Card.test.tsx
@@ -83,6 +83,28 @@ describe('CardHeader', () => {
       expect(tooltip.closest('[data-align]')).toHaveAttribute('data-align', 'end');
     });
 
+    it('aligns long array tooltips end', async () => {
+      const user = userEvent.setup();
+
+      render(<CardHeader tooltip={['Tooltip ', <span key="content">content.</span>]} />);
+
+      await user.hover(screen.getByRole('button', { name: 'Info' }));
+
+      const tooltip = await screen.findByRole('tooltip');
+      expect(tooltip.closest('[data-align]')).toHaveAttribute('data-align', 'end');
+    });
+
+    it('keeps short numeric tooltips centered', async () => {
+      const user = userEvent.setup();
+
+      render(<CardHeader tooltip={12345} />);
+
+      await user.hover(screen.getByRole('button', { name: 'Info' }));
+
+      const tooltip = await screen.findByRole('tooltip');
+      expect(tooltip.closest('[data-align]')).toHaveAttribute('data-align', 'center');
+    });
+
     it('returns null when no title, subtitle, or tooltip is provided', () => {
       const { container } = render(<CardHeader />);
 

--- a/src/components/shared/Card/Card.tsx
+++ b/src/components/shared/Card/Card.tsx
@@ -26,6 +26,28 @@ type CardHeaderProps = {
   tooltip?: React.ReactNode;
 };
 
+const LONG_TOOLTIP_TEXT_LENGTH = 15;
+
+const getTooltipText = (tooltip: React.ReactNode): string => {
+  if (typeof tooltip === 'string' || typeof tooltip === 'number') {
+    return String(tooltip);
+  }
+
+  if (Array.isArray(tooltip)) {
+    return tooltip.map(getTooltipText).join('');
+  }
+
+  return '';
+};
+
+const getCardHeaderTooltipAlign = (
+  tooltip: React.ReactNode,
+): React.ComponentProps<typeof Tooltip>['align'] => {
+  const tooltipText = getTooltipText(tooltip).trim();
+
+  return tooltipText.length > LONG_TOOLTIP_TEXT_LENGTH ? 'end' : 'center';
+};
+
 export const CardHeader: React.FC<CardHeaderProps> = ({ title, subtitle, tooltip }) => {
   if (!title && !subtitle && !tooltip) {
     return null;
@@ -38,7 +60,7 @@ export const CardHeader: React.FC<CardHeaderProps> = ({ title, subtitle, tooltip
         {tooltip && (
           <Tooltip
             side="top"
-            align="center"
+            align={getCardHeaderTooltipAlign(tooltip)}
             trigger={
               <button className={styles.cardHeaderTooltipButton} aria-label="Info">
                 <IconInfoCircle />

--- a/src/components/shared/Card/Card.tsx
+++ b/src/components/shared/Card/Card.tsx
@@ -37,6 +37,10 @@ const getTooltipText = (tooltip: React.ReactNode): string => {
     return tooltip.map(getTooltipText).join('');
   }
 
+  if (React.isValidElement<{ children?: React.ReactNode }>(tooltip)) {
+    return getTooltipText(tooltip.props.children);
+  }
+
   return '';
 };
 


### PR DESCRIPTION
# Why is this pull-request needed?

Long card header info tooltips can overlap the browser scrollbar when the card is positioned near the right edge of a dashboard. This makes the tooltip harder to read and looks broken for embedded dashboard users.

# Main changes

- Align `CardHeader` info tooltips conditionally based on tooltip length.
- Keep tooltips up to 15 characters centered to preserve the existing behavior for short copy.
- Align tooltips longer than 15 characters to `end`, so wider tooltip content expands left from the info icon and stays away from the right edge.
- Add tests covering both the centered and `end` alignment cases.

# Test evidence
https://www.loom.com/share/000b85261ac7430488b1f5515ff87e47

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Card header tooltips now intelligently adjust their alignment based on content length, ensuring optimal positioning and improved visual consistency. Short tooltips align to center, while longer content automatically aligns to the end for better readability.

* **Tests**
  * Added test coverage for card header tooltip alignment behavior to verify proper positioning across different tooltip text lengths.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->