### PR TITLE
TPS-1404 :date range impro

### DIFF
--- a/.changeset/fresh-pugs-bathe.md
+++ b/.changeset/fresh-pugs-bathe.md
@@ -1,0 +1,5 @@
+---
+'@embeddable.com/remarkable-ui': patch
+---
+
+DateRangePicker mas limit is now 5 years from the current date

--- a/src/components/editors/dates/DateRangePicker/DateRangePicker.tsx
+++ b/src/components/editors/dates/DateRangePicker/DateRangePicker.tsx
@@ -12,6 +12,8 @@ export type DateRangePickerProps = {
   onChange: (dateRange: DateRange | undefined) => void;
 };
 
+const YEARS_AFTER = 5;
+
 export const DateRangePicker: React.FC<DateRangePickerProps> = ({
   value,
   numberOfMonths = 1,
@@ -19,6 +21,7 @@ export const DateRangePicker: React.FC<DateRangePickerProps> = ({
   onChange,
 }) => {
   const [month, setMonth] = useState<Date>(value?.from ?? new Date());
+  const currentYear = new Date().getFullYear();
 
   const handleChange = (range: DateRange | undefined) => {
     if (range?.to) {
@@ -26,9 +29,6 @@ export const DateRangePicker: React.FC<DateRangePickerProps> = ({
     }
     onChange(range);
   };
-
-  const now = new Date();
-  const endMonth = new Date(now.getFullYear() + 2, now.getMonth());
 
   return (
     <DayPicker
@@ -45,7 +45,7 @@ export const DateRangePicker: React.FC<DateRangePickerProps> = ({
       timeZone="UTC"
       showOutsideDays
       captionLayout="dropdown-years"
-      endMonth={endMonth}
+      endMonth={new Date(currentYear + YEARS_AFTER, 11)}
       animate
     />
   );

--- a/src/components/editors/dates/DateRangePicker/DateRangePickerChevron.tsx
+++ b/src/components/editors/dates/DateRangePicker/DateRangePickerChevron.tsx
@@ -10,18 +10,35 @@ type DateRangePickerChevronProps = {
 
 const SMALL_SIZE = 18;
 
+const getRotation = (
+  orientation: DateRangePickerChevronProps['orientation'],
+): string | undefined => {
+  switch (orientation) {
+    case 'up':
+      return 'rotate(90deg)';
+    case 'down':
+      return 'rotate(270deg)';
+    case 'right':
+      return 'rotate(180deg)';
+    case 'left':
+    default:
+      return undefined;
+  }
+};
+
 export const DateRangePickerChevron = ({
   orientation,
   size,
+  className,
 }: DateRangePickerChevronProps): React.JSX.Element => {
-  const rotation = orientation === 'left' ? undefined : 'rotate(180deg)';
+  const rotation = getRotation(orientation);
 
   const isSmallChevron = size === SMALL_SIZE;
 
   return (
     <span
       data-testid="date-range-picker-chevron"
-      className={clsx(styles.chevron, isSmallChevron && styles.small)}
+      className={clsx(styles.chevron, isSmallChevron && styles.small, className)}
       style={{
         transform: rotation,
       }}


### PR DESCRIPTION
# Why is this pull-request needed?

Client needs to select dates after the 2 years from now.

# Main changes

Date range now goes until 5 years from now.

# Test evidence


https://github.com/user-attachments/assets/18d41731-11d6-446a-b1fc-fabb539d70dd




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Date range selection is now limited to a maximum of 5 years from the current date.
  * Chevron icons in the date picker now support more consistent orientation handling and styling.

* **Chores**
  * Updated the release note entry to reflect the new patch release.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->