### PR TITLE
[RUI-239] Configurable pivot table

### DIFF
--- a/.changeset/pink-pillows-stack.md
+++ b/.changeset/pink-pillows-stack.md
@@ -1,0 +1,5 @@
+---
+'@embeddable.com/remarkable-ui': patch
+---
+
+PivotTable: when multiple column aggregations (Sum, Min, Max, Average) are shown, every total row now stays sticky, stacked at the bottom, instead of only the final one being pinned. Also added `sumLabel` / `minLabel` / `maxLabel` / `averageLabel` support end-to-end so the total row labels can be customised/translated.

--- a/src/components/charts/tables/HeatMap/HeatMap.test.tsx
+++ b/src/components/charts/tables/HeatMap/HeatMap.test.tsx
@@ -1,5 +1,6 @@
 import { render, screen } from '@testing-library/react';
-import { describe, expect, it } from 'vitest';
+import userEvent from '@testing-library/user-event';
+import { describe, expect, it, vi } from 'vitest';
 import { HeatMap } from './HeatMap';
 
 type Row = { region: string; quarter: string; sales: number | null };
@@ -72,6 +73,63 @@ describe('HeatMap', () => {
       render(<HeatMap {...DEFAULT_PROPS} data={dataWithNull} showValues displayNullAs="N/A" />);
 
       expect(screen.getByText('N/A')).toBeInTheDocument();
+    });
+  });
+
+  describe('onCellClick', () => {
+    it('calls onCellClick with row and column values when a cell is clicked', async () => {
+      const user = userEvent.setup();
+      const handleClick = vi.fn();
+
+      render(<HeatMap {...DEFAULT_PROPS} onCellClick={handleClick} />);
+
+      // First button is the North × Q1 cell (columns render in data order)
+      await user.click(screen.getAllByRole('button')[0]!);
+
+      expect(handleClick).toHaveBeenCalledWith({
+        rowDimensionValue: 'North',
+        columnDimensionValue: 'Q1',
+      });
+    });
+
+    it('triggers onCellClick on Enter key press', async () => {
+      const user = userEvent.setup();
+      const handleClick = vi.fn();
+
+      render(<HeatMap {...DEFAULT_PROPS} onCellClick={handleClick} />);
+
+      const [firstCellEnter] = screen.getAllByRole('button');
+      firstCellEnter!.focus();
+      await user.keyboard('{Enter}');
+
+      expect(handleClick).toHaveBeenCalledTimes(1);
+    });
+
+    it('triggers onCellClick on Space key press', async () => {
+      const user = userEvent.setup();
+      const handleClick = vi.fn();
+
+      render(<HeatMap {...DEFAULT_PROPS} onCellClick={handleClick} />);
+
+      const [firstCellSpace] = screen.getAllByRole('button');
+      firstCellSpace!.focus();
+      await user.keyboard(' ');
+
+      expect(handleClick).toHaveBeenCalledTimes(1);
+    });
+
+    it('renders cells as buttons with tabIndex when onCellClick is provided', () => {
+      render(<HeatMap {...DEFAULT_PROPS} onCellClick={vi.fn()} />);
+
+      const buttons = screen.getAllByRole('button');
+      expect(buttons.length).toBeGreaterThan(0);
+      buttons.forEach((btn) => expect(btn).toHaveAttribute('tabindex', '0'));
+    });
+
+    it('renders no button role or tabIndex on cells without onCellClick', () => {
+      render(<HeatMap {...DEFAULT_PROPS} />);
+
+      expect(screen.queryAllByRole('button')).toHaveLength(0);
     });
   });
 

--- a/src/components/charts/tables/HeatMap/HeatMap.tsx
+++ b/src/components/charts/tables/HeatMap/HeatMap.tsx
@@ -160,6 +160,7 @@ export const HeatMap = <T extends Record<string, unknown>>({
                         color,
                         cursor: onCellClick ? 'pointer' : undefined,
                         ...getTableCellWidthStyle(columnWidth),
+                        ...(onCellClick ? { cursor: 'pointer' } : {}),
                       }}
                       onClick={
                         onCellClick

--- a/src/components/charts/tables/HeatMap/HeatMap.tsx
+++ b/src/components/charts/tables/HeatMap/HeatMap.tsx
@@ -155,20 +155,27 @@ export const HeatMap = <T extends Record<string, unknown>>({
                   return (
                     <td
                       key={`cell-${rv}-${cv}`}
+                      role={onCellClick ? 'button' : undefined}
+                      tabIndex={onCellClick ? 0 : undefined}
                       style={{
                         background,
                         color,
-                        cursor: onCellClick ? 'pointer' : undefined,
-                        ...getTableCellWidthStyle(columnWidth),
                         ...(onCellClick ? { cursor: 'pointer' } : {}),
+                        ...getTableCellWidthStyle(columnWidth),
                       }}
                       onClick={
                         onCellClick
-                          ? () =>
-                              onCellClick({
-                                rowDimensionValue: rv,
-                                columnDimensionValue: cv,
-                              })
+                          ? () => onCellClick({ rowDimensionValue: rv, columnDimensionValue: cv })
+                          : undefined
+                      }
+                      onKeyDown={
+                        onCellClick
+                          ? (e) => {
+                              if (e.key === 'Enter' || e.key === ' ') {
+                                e.preventDefault();
+                                onCellClick({ rowDimensionValue: rv, columnDimensionValue: cv });
+                              }
+                            }
                           : undefined
                       }
                     >

--- a/src/components/charts/tables/PivotTable/PivotTable.stories.tsx
+++ b/src/components/charts/tables/PivotTable/PivotTable.stories.tsx
@@ -85,21 +85,8 @@ const meta = {
     measures,
     rowDimension,
     columnDimension,
-    rowTotalsFor: [],
-    columnTotalsFor: [],
-    totalLabel: 'Total',
     firstColumnWidth: 150,
     columnWidth: 100,
-  },
-  argTypes: {
-    columnTotalsFor: {
-      options: ['orders', 'cost'],
-      control: { type: 'check' },
-    },
-    rowTotalsFor: {
-      options: ['orders', 'cost'],
-      control: { type: 'check' },
-    },
   },
 } satisfies Meta<typeof PivotTable>;
 
@@ -109,10 +96,30 @@ type Story = StoryObj<typeof meta>;
 
 export const Default: Story = {};
 
-export const WithTotals: Story = {
+export const WithSum: Story = {
   args: {
-    rowTotalsFor: ['orders', 'cost'],
-    columnTotalsFor: ['orders', 'cost'],
+    rowSumFor: ['orders', 'cost'],
+    columnSumFor: ['orders', 'cost'],
+  },
+};
+
+export const WithMinAndMax: Story = {
+  args: {
+    rowMinFor: ['orders', 'cost'],
+    rowMaxFor: ['orders', 'cost'],
+    columnMinFor: ['orders', 'cost'],
+    columnMaxFor: ['orders', 'cost'],
+  },
+};
+
+export const WithMultipleAggregations: Story = {
+  args: {
+    rowSumFor: ['orders', 'cost'],
+    rowAverageFor: ['orders'],
+    rowMinFor: ['orders'],
+    rowMaxFor: ['orders'],
+    columnSumFor: ['orders', 'cost'],
+    columnAverageFor: ['orders'],
   },
 };
 
@@ -124,7 +131,6 @@ const ExpandableRowsStory = (args: PivotTableProps<Data>) => {
   const [subRowsByRow, setSubRowsByRow] = useState(new Map<string, Data[]>());
   const [loadingRows, setLoadingRows] = useState(new Set<string>());
 
-  // Split a parent value across cities so sub-rows sum to parent
   const splitValue = (
     parentValue: number | null,
     cityIndex: number,
@@ -138,15 +144,11 @@ const ExpandableRowsStory = (args: PivotTableProps<Data>) => {
 
   const handleRowExpand = async (rowKey: string) => {
     setLoadingRows((prev) => new Set(prev).add(rowKey));
-
-    // Simulate API call
     await new Promise((resolve) => setTimeout(resolve, 1000));
 
-    // Get parent data for this row
     const parentRows = data.filter((d) => d.country === rowKey);
     const cities = ['City A', 'City B'];
 
-    // Sub-row values sum to parent values so percentages add up correctly
     const mockSubRows: Data[] = cities.flatMap((city, cityIdx) =>
       parentRows.map((pd) => ({
         country: rowKey,

--- a/src/components/charts/tables/PivotTable/PivotTable.test.tsx
+++ b/src/components/charts/tables/PivotTable/PivotTable.test.tsx
@@ -172,6 +172,64 @@ describe('PivotTable', () => {
     });
   });
 
+  describe('grand-total intersection', () => {
+    it('shows the row-agg type value at the column-footer × row-agg intersection, not the footer type', () => {
+      // columnSumFor → Sum footer row; rowMinFor → Min column
+      // Grand sum = 390; grand min = 80.
+      // The intersection cell (Sum footer × Min column) must show 80, not 390.
+      render(<PivotTable {...DEFAULT_PROPS} columnSumFor={['revenue']} rowMinFor={['revenue']} />);
+
+      // 390 (grand sum) must not appear — the Min column should never show a sum
+      expect(screen.queryByTitle('390')).not.toBeInTheDocument();
+      // 80 (grand min) appears in both the UK-Jan regular cell and the intersection
+      expect(screen.getAllByTitle('80').length).toBeGreaterThan(0);
+    });
+  });
+
+  describe('row aggregation percentage', () => {
+    it('shows percentage relative to grand total, not 100%', () => {
+      // US revenue sum = 220, grand revenue sum = 390 → ≈56%
+      render(
+        <PivotTable
+          {...DEFAULT_PROPS}
+          rowSumFor={['revenue']}
+          measures={[
+            {
+              key: 'revenue' as const,
+              label: 'Revenue',
+              showAsPercentage: true,
+              percentageDecimalPlaces: 0,
+            },
+          ]}
+        />,
+      );
+
+      // 100% would appear if the bug is present (row agg used as its own denominator)
+      expect(screen.queryByTitle('100%')).not.toBeInTheDocument();
+      // US: 220/390 ≈ 56%; UK: 170/390 ≈ 44%
+      expect(screen.getAllByTitle('56%').length).toBeGreaterThan(0);
+      expect(screen.getAllByTitle('44%').length).toBeGreaterThan(0);
+    });
+  });
+
+  describe('header guard for invalid measure keys', () => {
+    it('skips invalid measure keys in row-agg subheader without creating extra columns', () => {
+      // rowSumFor references 'cost' (valid) and 'nonexistent' (not in measures)
+      // Only 'Revenue' subheader should appear, not 'nonexistent'
+      render(
+        <PivotTable
+          {...DEFAULT_PROPS}
+          rowSumFor={['revenue', 'nonexistent' as (typeof DEFAULT_PROPS.measures)[0]['key']]}
+        />,
+      );
+
+      const revenueHeaders = screen.getAllByText('Revenue');
+      // Only the valid measure appears in the agg subheader
+      expect(revenueHeaders.length).toBeGreaterThan(0);
+      expect(screen.queryByText('nonexistent')).not.toBeInTheDocument();
+    });
+  });
+
   describe('loading rows', () => {
     it('shows loading indicator for rows in loadingRows set', async () => {
       const loadingRows = new Set(['US']);

--- a/src/components/charts/tables/PivotTable/PivotTable.test.tsx
+++ b/src/components/charts/tables/PivotTable/PivotTable.test.tsx
@@ -50,27 +50,68 @@ describe('PivotTable', () => {
     });
   });
 
-  describe('row totals', () => {
-    it('renders totals column header when rowTotalsFor is specified', () => {
-      render(<PivotTable {...DEFAULT_PROPS} rowTotalsFor={['revenue']} totalLabel="Total" />);
+  describe('row aggregations', () => {
+    it('renders Sum group header when rowSumFor is specified', () => {
+      render(<PivotTable {...DEFAULT_PROPS} rowSumFor={['revenue']} />);
 
-      expect(screen.getByText('Total')).toBeInTheDocument();
+      expect(screen.getByText('Sum')).toBeInTheDocument();
     });
 
-    it('does not render totals column when rowTotalsFor is empty', () => {
-      render(<PivotTable {...DEFAULT_PROPS} rowTotalsFor={[]} />);
+    it('renders Min and Max group headers when both props are specified', () => {
+      render(<PivotTable {...DEFAULT_PROPS} rowMinFor={['revenue']} rowMaxFor={['revenue']} />);
 
-      expect(screen.queryByText('Total')).not.toBeInTheDocument();
+      expect(screen.getByText('Min')).toBeInTheDocument();
+      expect(screen.getByText('Max')).toBeInTheDocument();
+    });
+
+    it('renders Average group header when rowAverageFor is specified', () => {
+      render(<PivotTable {...DEFAULT_PROPS} rowAverageFor={['revenue']} />);
+
+      expect(screen.getByText('Average')).toBeInTheDocument();
+    });
+
+    it('renders no aggregation columns when no row agg props are set', () => {
+      render(<PivotTable {...DEFAULT_PROPS} />);
+
+      expect(screen.queryByText('Sum')).not.toBeInTheDocument();
+      expect(screen.queryByText('Min')).not.toBeInTheDocument();
+      expect(screen.queryByText('Max')).not.toBeInTheDocument();
+      expect(screen.queryByText('Average')).not.toBeInTheDocument();
+    });
+
+    it('renders correct sum value in row aggregation cell', () => {
+      render(<PivotTable {...DEFAULT_PROPS} rowSumFor={['revenue']} />);
+
+      // US row: 100 + 120 = 220
+      expect(screen.getByTitle('220')).toBeInTheDocument();
     });
   });
 
-  describe('column totals', () => {
-    it('renders a totals row when columnTotalsFor is specified', () => {
-      render(
-        <PivotTable {...DEFAULT_PROPS} columnTotalsFor={['revenue']} totalLabel="Grand Total" />,
-      );
+  describe('column aggregations', () => {
+    it('renders a Sum footer row when columnSumFor is specified', () => {
+      render(<PivotTable {...DEFAULT_PROPS} columnSumFor={['revenue']} />);
 
-      expect(screen.getByText('Grand Total')).toBeInTheDocument();
+      expect(screen.getByText('Sum')).toBeInTheDocument();
+    });
+
+    it('renders Average footer row when columnAverageFor is specified', () => {
+      render(<PivotTable {...DEFAULT_PROPS} columnAverageFor={['revenue']} />);
+
+      expect(screen.getByText('Average')).toBeInTheDocument();
+    });
+
+    it('renders multiple footer rows when multiple column agg props are set', () => {
+      render(<PivotTable {...DEFAULT_PROPS} columnMinFor={['revenue']} columnMaxFor={['revenue']} />);
+
+      expect(screen.getByText('Min')).toBeInTheDocument();
+      expect(screen.getByText('Max')).toBeInTheDocument();
+    });
+
+    it('renders no footer rows when no column agg props are set', () => {
+      render(<PivotTable {...DEFAULT_PROPS} />);
+
+      expect(screen.queryByText('Sum')).not.toBeInTheDocument();
+      expect(screen.queryByText('Average')).not.toBeInTheDocument();
     });
   });
 

--- a/src/components/charts/tables/PivotTable/PivotTable.test.tsx
+++ b/src/components/charts/tables/PivotTable/PivotTable.test.tsx
@@ -101,10 +101,34 @@ describe('PivotTable', () => {
     });
 
     it('renders multiple footer rows when multiple column agg props are set', () => {
-      render(<PivotTable {...DEFAULT_PROPS} columnMinFor={['revenue']} columnMaxFor={['revenue']} />);
+      render(
+        <PivotTable {...DEFAULT_PROPS} columnMinFor={['revenue']} columnMaxFor={['revenue']} />,
+      );
 
       expect(screen.getByText('Min')).toBeInTheDocument();
       expect(screen.getByText('Max')).toBeInTheDocument();
+    });
+
+    it('stacks every footer row as sticky, offset from the bottom by its position', () => {
+      render(
+        <PivotTable {...DEFAULT_PROPS} columnMinFor={['revenue']} columnMaxFor={['revenue']} />,
+      );
+
+      // Groups render in canonical order (min then max), so Min sits one row above the
+      // bottom and Max sits flush against it.
+      const minRow = screen.getByText('Min').closest('tr');
+      const maxRow = screen.getByText('Max').closest('tr');
+
+      const minStyle = minRow?.getAttribute('style') ?? '';
+      const maxStyle = maxRow?.getAttribute('style') ?? '';
+
+      // Both pin to the bottom edge only.
+      expect(minStyle).toContain('top: auto');
+      expect(maxStyle).toContain('top: auto');
+
+      // Max is the last row (0 rows below); Min has 1 row below it.
+      expect(maxStyle).toContain('* 0');
+      expect(minStyle).toContain('* 1');
     });
 
     it('renders no footer rows when no column agg props are set', () => {

--- a/src/components/charts/tables/PivotTable/PivotTable.tsx
+++ b/src/components/charts/tables/PivotTable/PivotTable.tsx
@@ -16,6 +16,7 @@ import {
   useProgressiveRows,
 } from './PivotTable.utils';
 
+/* eslint-disable @typescript-eslint/no-explicit-any */
 const toGroups = (
   sum: string[],
   min: string[],
@@ -29,7 +30,6 @@ const toGroups = (
     { type: 'average' as const, measureKeys: average },
   ].filter((g) => g.measureKeys.length > 0);
 
-/* eslint-disable @typescript-eslint/no-explicit-any */
 export const PivotTable: FC<PivotTableProps<any>> = ({
   columnWidth,
   firstColumnWidth,
@@ -109,10 +109,7 @@ export const PivotTable: FC<PivotTableProps<any>> = ({
     return map;
   }, [measures]);
 
-  const measureByKey = useMemo(
-    () => new Map(measures.map((m) => [String(m.key), m])),
-    [measures],
-  );
+  const measureByKey = useMemo(() => new Map(measures.map((m) => [String(m.key), m])), [measures]);
 
   const { colAggs, rowAggs, grandAggs } = usePivotAggregations(
     data,
@@ -158,7 +155,13 @@ export const PivotTable: FC<PivotTableProps<any>> = ({
         const value = object?.[measure.key];
         const key = `${keyPrefix}-${columnValue}-${measure.key}-${idx}`;
         const mi = measureIndexByKey.get(String(measure.key)) ?? -1;
-        const colTotal = getAggregatedValue(colAggs, String(columnValue), mi, 'sum', measures.length);
+        const colTotal = getAggregatedValue(
+          colAggs,
+          String(columnValue),
+          mi,
+          'sum',
+          measures.length,
+        );
         const displayValue = getCellDisplayValue(value, measure, object, colTotal);
 
         return (
@@ -201,7 +204,13 @@ export const PivotTable: FC<PivotTableProps<any>> = ({
         const measureIndex = measureIndexByKey.get(measureKey) ?? -1;
         const key = `${keyPrefix}-${group.type}-${gi}-${measureKey}-${idx}`;
         const value = getAggValue(group.type, measureKey, measureIndex);
-        const displayValue = getAggCellDisplayValue(group.type, value, measure, sourceAggs, measureIndex);
+        const displayValue = getAggCellDisplayValue(
+          group.type,
+          value,
+          measure,
+          sourceAggs,
+          measureIndex,
+        );
 
         return (
           <td key={key} className={tableStyles.boltCell} title={String(displayValue)}>
@@ -271,7 +280,7 @@ export const PivotTable: FC<PivotTableProps<any>> = ({
   const renderColumnAggRow = (
     group: PivotAggregationConfig<any>,
     gi: number,
-    isLast: boolean,
+    rowsBelow: number,
   ) => {
     const groupLabel = aggLabels[group.type];
     const groupMeasureKeySet = new Set(group.measureKeys);
@@ -279,7 +288,13 @@ export const PivotTable: FC<PivotTableProps<any>> = ({
     return (
       <tr
         key={`col-agg-row-${group.type}-${gi}`}
-        className={isLast ? tableStyles.stickyLastRow : undefined}
+        className={tableStyles.stickyLastRow}
+        // Stack each total row above the one below it. `top: auto` disables top-sticking
+        // so the rows only pin to the bottom edge. Cell height is fixed by the theme.
+        style={{
+          top: 'auto',
+          bottom: `calc(var(--em-tablechart-cell-height, 2.5rem) * ${rowsBelow})`,
+        }}
       >
         <th
           scope="row"
@@ -294,10 +309,20 @@ export const PivotTable: FC<PivotTableProps<any>> = ({
           measures.map((measure, idx) => {
             const key = `col-agg-${group.type}-${gi}-${String(columnValue)}-${measure.key}-${idx}`;
             if (!groupMeasureKeySet.has(measure.key)) {
-              return <td key={key} className={tableStyles.boltCell}>{''}</td>;
+              return (
+                <td key={key} className={tableStyles.boltCell}>
+                  {''}
+                </td>
+              );
             }
             const mi = measureIndexByKey.get(String(measure.key)) ?? -1;
-            const value = getAggregatedValue(colAggs, String(columnValue), mi, group.type, measures.length);
+            const value = getAggregatedValue(
+              colAggs,
+              String(columnValue),
+              mi,
+              group.type,
+              measures.length,
+            );
             const displayValue = getColumnAggDisplayValue(group.type, value, measure);
             return (
               <td key={key} className={tableStyles.boltCell} title={String(displayValue)}>
@@ -510,7 +535,9 @@ export const PivotTable: FC<PivotTableProps<any>> = ({
 
             {hasColumnAggs &&
               columnAggregationsFor.map((group: PivotAggregationConfig<any>, gi: number) =>
-                renderColumnAggRow(group, gi, gi === columnAggregationsFor.length - 1),
+                // Every aggregation total row is sticky, stacked at the bottom: a row's
+                // offset from the bottom equals the number of aggregation rows below it.
+                renderColumnAggRow(group, gi, columnAggregationsFor.length - 1 - gi),
               )}
           </tbody>
         </table>

--- a/src/components/charts/tables/PivotTable/PivotTable.tsx
+++ b/src/components/charts/tables/PivotTable/PivotTable.tsx
@@ -338,9 +338,9 @@ export const PivotTable: FC<PivotTableProps<any>> = ({
               const measure = measureByKey.get(measureKey);
               const measureIndex = measureIndexByKey.get(measureKey) ?? -1;
               const key = `grand-agg-${group.type}-${gi}-${rowGroup.type}-${rgi}-${measureKey}-${idx}`;
-              const value = grandAggs[group.type][measureIndex] ?? 0;
+              const value = grandAggs[rowGroup.type][measureIndex] ?? 0;
               const displayValue = measure
-                ? getColumnAggDisplayValue(group.type, value, measure)
+                ? getColumnAggDisplayValue(rowGroup.type, value, measure)
                 : value;
               return (
                 <td key={key} className={tableStyles.boltCell} title={String(displayValue)}>
@@ -394,11 +394,12 @@ export const PivotTable: FC<PivotTableProps<any>> = ({
               {hasRowAggs &&
                 rowAggregationsFor.map((group: PivotAggregationConfig<any>, gi: number) => {
                   const label = aggLabels[group.type];
+                  const validCount = group.measureKeys.filter((k) => measureByKey.has(k)).length;
                   return (
                     <th
                       key={`agg-group-${group.type}-${gi}`}
                       scope="colgroup"
-                      colSpan={group.measureKeys.length}
+                      colSpan={validCount}
                       className={tableStyles.boltCell}
                       title={label}
                     >
@@ -433,15 +434,16 @@ export const PivotTable: FC<PivotTableProps<any>> = ({
                 rowAggregationsFor.flatMap((group: PivotAggregationConfig<any>, gi: number) =>
                   group.measureKeys.map((measureKey: string, idx: number) => {
                     const measure = measureByKey.get(measureKey);
+                    if (!measure) return null;
                     return (
                       <th
                         key={`agg-sub-${group.type}-${gi}-${measureKey}-${idx}`}
                         scope="col"
                         className={tableStyles.boltCell}
-                        title={measure?.label ?? measureKey}
+                        title={measure.label}
                         style={getTableCellWidthStyle(columnWidth)}
                       >
-                        {measure?.label ?? measureKey}
+                        {measure.label}
                       </th>
                     );
                   }),
@@ -523,7 +525,7 @@ export const PivotTable: FC<PivotTableProps<any>> = ({
                           _type,
                           measures.length,
                         ),
-                      rowAggs.get(String(row)) ?? grandAggs,
+                      grandAggs,
                       `row-agg-${String(row)}`,
                     )}
                   </tr>

--- a/src/components/charts/tables/PivotTable/PivotTable.tsx
+++ b/src/components/charts/tables/PivotTable/PivotTable.tsx
@@ -1,18 +1,33 @@
 import { FC, Fragment, useMemo, useState } from 'react';
 import tableStyles from '../tables.module.css';
 import clsx from 'clsx';
-import { PivotTableProps } from './PivotTable.types';
+import { PivotAggregationConfig, PivotAggregationType, PivotTableProps } from './PivotTable.types';
 import { getTableCellWidthStyle } from '../tables.utils';
 import { IconLoader2, IconChevronDown, IconChevronRight } from '@tabler/icons-react';
 import {
+  AGG_DEFAULT_LABELS,
+  AggResult,
   buildCellMap,
+  computeSubRowAggregation,
   getCellDisplayValue,
+  getAggregatedValue,
   getPercentageDisplay,
-  getMeasureTotal,
-  computeSubRowTotal,
+  usePivotAggregations,
   useProgressiveRows,
-  usePivotTotals,
 } from './PivotTable.utils';
+
+const toGroups = (
+  sum: string[],
+  min: string[],
+  max: string[],
+  average: string[],
+): PivotAggregationConfig<any>[] =>
+  [
+    { type: 'sum' as const, measureKeys: sum },
+    { type: 'min' as const, measureKeys: min },
+    { type: 'max' as const, measureKeys: max },
+    { type: 'average' as const, measureKeys: average },
+  ].filter((g) => g.measureKeys.length > 0);
 
 /* eslint-disable @typescript-eslint/no-explicit-any */
 export const PivotTable: FC<PivotTableProps<any>> = ({
@@ -25,9 +40,18 @@ export const PivotTable: FC<PivotTableProps<any>> = ({
   progressive = true,
   batchSize = 100,
   batchDelayMs = 0,
-  rowTotalsFor = [],
-  columnTotalsFor = [],
-  totalLabel = 'Total',
+  rowSumFor = [],
+  rowMinFor = [],
+  rowMaxFor = [],
+  rowAverageFor = [],
+  columnSumFor = [],
+  columnMinFor = [],
+  columnMaxFor = [],
+  columnAverageFor = [],
+  sumLabel,
+  minLabel,
+  maxLabel,
+  averageLabel,
   className,
   expandableRows = false,
   subRowsByRow,
@@ -35,8 +59,24 @@ export const PivotTable: FC<PivotTableProps<any>> = ({
   onRowExpand,
   subRowDimension,
 }) => {
-  // Default subRowDimension to rowDimension if not provided
   const effectiveSubRowDimension = subRowDimension ?? rowDimension;
+
+  const aggLabels: Record<string, string> = {
+    sum: sumLabel ?? AGG_DEFAULT_LABELS.sum,
+    min: minLabel ?? AGG_DEFAULT_LABELS.min,
+    max: maxLabel ?? AGG_DEFAULT_LABELS.max,
+    average: averageLabel ?? AGG_DEFAULT_LABELS.average,
+  };
+
+  const rowAggregationsFor = useMemo(
+    () => toGroups(rowSumFor, rowMinFor, rowMaxFor, rowAverageFor),
+    [rowSumFor, rowMinFor, rowMaxFor, rowAverageFor],
+  );
+  const columnAggregationsFor = useMemo(
+    () => toGroups(columnSumFor, columnMinFor, columnMaxFor, columnAverageFor),
+    [columnSumFor, columnMinFor, columnMaxFor, columnAverageFor],
+  );
+
   const rowValues = useMemo(() => {
     const s = new Set<string>();
     for (const d of data) {
@@ -60,10 +100,8 @@ export const PivotTable: FC<PivotTableProps<any>> = ({
     [data, rowDimension.key, columnDimension.key],
   );
 
-  const rowTotalsSet = useMemo(() => new Set<string>(rowTotalsFor), [rowTotalsFor]);
-  const columnTotalsSet = useMemo(() => new Set<string>(columnTotalsFor), [columnTotalsFor]);
-  const hasRowTotals = rowTotalsSet.size > 0;
-  const hasColumnTotals = columnTotalsSet.size > 0;
+  const hasRowAggs = rowAggregationsFor.length > 0;
+  const hasColumnAggs = columnAggregationsFor.length > 0;
 
   const measureIndexByKey = useMemo(() => {
     const map = new Map<string, number>();
@@ -71,7 +109,12 @@ export const PivotTable: FC<PivotTableProps<any>> = ({
     return map;
   }, [measures]);
 
-  const { colTotals, rowTotals, grandTotals } = usePivotTotals(
+  const measureByKey = useMemo(
+    () => new Map(measures.map((m) => [String(m.key), m])),
+    [measures],
+  );
+
+  const { colAggs, rowAggs, grandAggs } = usePivotAggregations(
     data,
     measures,
     rowDimension.key,
@@ -86,19 +129,14 @@ export const PivotTable: FC<PivotTableProps<any>> = ({
     setExpandedRows((prev) => {
       const next = new Set(prev);
       const wasExpanded = next.has(rowKey);
-
       if (wasExpanded) {
-        // Collapse the row
         next.delete(rowKey);
       } else {
-        // Expand the row and trigger data fetch
         next.add(rowKey);
-        // Only call onRowExpand if we don't already have the data
         if (!subRowsByRow?.has(rowKey)) {
           onRowExpand?.(rowKey);
         }
       }
-
       return next;
     });
   };
@@ -120,7 +158,7 @@ export const PivotTable: FC<PivotTableProps<any>> = ({
         const value = object?.[measure.key];
         const key = `${keyPrefix}-${columnValue}-${measure.key}-${idx}`;
         const mi = measureIndexByKey.get(String(measure.key)) ?? -1;
-        const colTotal = getMeasureTotal(colTotals, String(columnValue), mi, measures.length);
+        const colTotal = getAggregatedValue(colAggs, String(columnValue), mi, 'sum', measures.length);
         const displayValue = getCellDisplayValue(value, measure, object, colTotal);
 
         return (
@@ -131,30 +169,47 @@ export const PivotTable: FC<PivotTableProps<any>> = ({
       }),
     );
 
-  const renderRowTotalCells = (
-    getTotalValue: (measureKey: string, measureIndex: number) => number,
+  const getAggCellDisplayValue = (
+    type: PivotAggregationType,
+    value: number,
+    measure: any,
+    sourceAggs: AggResult,
+    measureIndex: number,
+  ): any => {
+    if (type === 'sum' && measure.showAsPercentage) {
+      const denominator = sourceAggs.sum[measureIndex] || 1;
+      if (typeof denominator === 'number' && denominator > 0) {
+        return getPercentageDisplay(
+          (value / denominator) * 100,
+          measure.percentageDecimalPlaces ?? 0,
+        );
+      }
+    }
+    return measure.accessor ? measure.accessor({ [measure.key]: value }) : value;
+  };
+
+  const renderRowAggCells = (
+    getAggValue: (type: PivotAggregationType, measureKey: string, measureIndex: number) => number,
+    sourceAggs: AggResult,
     keyPrefix: string,
   ) => {
-    if (!hasRowTotals) return null;
-    return measures
-      .filter((measure) => rowTotalsSet.has(measure.key))
-      .map((measure, idx) => {
-        const measureIndex = measureIndexByKey.get(measure.key) ?? -1;
-        const key = `${keyPrefix}-${measure.key}-${idx}`;
-        const value = getTotalValue(measure.key, measureIndex);
-        const displayValue = getCellDisplayValue(
-          value,
-          measure,
-          { [measure.key]: value },
-          grandTotals[measureIndex] || 1,
-        );
+    if (!hasRowAggs) return null;
+    return rowAggregationsFor.flatMap((group: PivotAggregationConfig<any>, gi: number) =>
+      group.measureKeys.map((measureKey: string, idx: number) => {
+        const measure = measureByKey.get(measureKey);
+        if (!measure) return null;
+        const measureIndex = measureIndexByKey.get(measureKey) ?? -1;
+        const key = `${keyPrefix}-${group.type}-${gi}-${measureKey}-${idx}`;
+        const value = getAggValue(group.type, measureKey, measureIndex);
+        const displayValue = getAggCellDisplayValue(group.type, value, measure, sourceAggs, measureIndex);
 
         return (
-          <td key={key} className={tableStyles.boltCell} title={displayValue}>
+          <td key={key} className={tableStyles.boltCell} title={String(displayValue)}>
             {displayValue}
           </td>
         );
-      });
+      }),
+    );
   };
 
   const renderSubRows = (rowKey: string, subRows: any[]) => {
@@ -185,13 +240,92 @@ export const PivotTable: FC<PivotTableProps<any>> = ({
             `sub-cell-${rowKey}-${subRowIdx}`,
           )}
 
-          {renderRowTotalCells(
-            (key) => computeSubRowTotal(subRowCellMap, String(subRowValue), columnValues, key),
-            `sub-total-${rowKey}-${subRowIdx}`,
+          {renderRowAggCells(
+            (type, measureKey) =>
+              computeSubRowAggregation(
+                subRowCellMap,
+                String(subRowValue),
+                columnValues,
+                measureKey,
+                type,
+              ),
+            grandAggs,
+            `sub-agg-${rowKey}-${subRowIdx}`,
           )}
         </tr>
       );
     });
+  };
+
+  const getColumnAggDisplayValue = (
+    type: PivotAggregationType,
+    value: number,
+    measure: any,
+  ): any => {
+    if (type === 'sum' && measure.showAsPercentage) {
+      return getPercentageDisplay(100, measure.percentageDecimalPlaces ?? 0);
+    }
+    return measure.accessor ? measure.accessor({ [measure.key]: value }) : value;
+  };
+
+  const renderColumnAggRow = (
+    group: PivotAggregationConfig<any>,
+    gi: number,
+    isLast: boolean,
+  ) => {
+    const groupLabel = aggLabels[group.type];
+    const groupMeasureKeySet = new Set(group.measureKeys);
+
+    return (
+      <tr
+        key={`col-agg-row-${group.type}-${gi}`}
+        className={isLast ? tableStyles.stickyLastRow : undefined}
+      >
+        <th
+          scope="row"
+          className={clsx(tableStyles.stickyFirstColumn, tableStyles.boltCell)}
+          title={groupLabel}
+          style={getTableCellWidthStyle(firstColumnWidth)}
+        >
+          {groupLabel}
+        </th>
+
+        {columnValues.flatMap((columnValue) =>
+          measures.map((measure, idx) => {
+            const key = `col-agg-${group.type}-${gi}-${String(columnValue)}-${measure.key}-${idx}`;
+            if (!groupMeasureKeySet.has(measure.key)) {
+              return <td key={key} className={tableStyles.boltCell}>{''}</td>;
+            }
+            const mi = measureIndexByKey.get(String(measure.key)) ?? -1;
+            const value = getAggregatedValue(colAggs, String(columnValue), mi, group.type, measures.length);
+            const displayValue = getColumnAggDisplayValue(group.type, value, measure);
+            return (
+              <td key={key} className={tableStyles.boltCell} title={String(displayValue)}>
+                {displayValue}
+              </td>
+            );
+          }),
+        )}
+
+        {hasRowAggs &&
+          rowAggregationsFor.flatMap((rowGroup: PivotAggregationConfig<any>, rgi: number) =>
+            rowGroup.measureKeys.map((measureKey: string, idx: number) => {
+              const measure = measureByKey.get(measureKey);
+              const measureIndex = measureIndexByKey.get(measureKey) ?? -1;
+              const key = `grand-agg-${group.type}-${gi}-${rowGroup.type}-${rgi}-${measureKey}-${idx}`;
+              const value = grandAggs[group.type][measureIndex] ?? 0;
+              const displayValue = measure
+                ? getColumnAggDisplayValue(group.type, value, measure)
+                : value;
+              return (
+                <td key={key} className={tableStyles.boltCell} title={String(displayValue)}>
+                  {displayValue}
+                </td>
+              );
+            }),
+          )}
+      </tr>
+    );
   };
 
   return (
@@ -232,17 +366,21 @@ export const PivotTable: FC<PivotTableProps<any>> = ({
                   </th>
                 );
               })}
-              {hasRowTotals && (
-                <th
-                  key="col-total-group"
-                  scope="colgroup"
-                  colSpan={Array.from(rowTotalsSet).length}
-                  className={tableStyles.boltCell}
-                  title={totalLabel}
-                >
-                  {totalLabel}
-                </th>
-              )}
+              {hasRowAggs &&
+                rowAggregationsFor.map((group: PivotAggregationConfig<any>, gi: number) => {
+                  const label = aggLabels[group.type];
+                  return (
+                    <th
+                      key={`agg-group-${group.type}-${gi}`}
+                      scope="colgroup"
+                      colSpan={group.measureKeys.length}
+                      className={tableStyles.boltCell}
+                      title={label}
+                    >
+                      {label}
+                    </th>
+                  );
+                })}
             </tr>
             <tr>
               <th
@@ -266,20 +404,23 @@ export const PivotTable: FC<PivotTableProps<any>> = ({
                   </th>
                 )),
               )}
-              {hasRowTotals &&
-                measures
-                  .filter((measure) => rowTotalsSet.has(measure.key))
-                  .map((measure, idx) => (
-                    <th
-                      key={`sub-total-${measure.key}-${idx}`}
-                      scope="col"
-                      className={tableStyles.boltCell}
-                      title={measure.label}
-                      style={getTableCellWidthStyle(columnWidth)}
-                    >
-                      {measure.label}
-                    </th>
-                  ))}
+              {hasRowAggs &&
+                rowAggregationsFor.flatMap((group: PivotAggregationConfig<any>, gi: number) =>
+                  group.measureKeys.map((measureKey: string, idx: number) => {
+                    const measure = measureByKey.get(measureKey);
+                    return (
+                      <th
+                        key={`agg-sub-${group.type}-${gi}-${measureKey}-${idx}`}
+                        scope="col"
+                        className={tableStyles.boltCell}
+                        title={measure?.label ?? measureKey}
+                        style={getTableCellWidthStyle(columnWidth)}
+                      >
+                        {measure?.label ?? measureKey}
+                      </th>
+                    );
+                  }),
+                )}
             </tr>
           </thead>
           <tbody>
@@ -306,7 +447,6 @@ export const PivotTable: FC<PivotTableProps<any>> = ({
 
               return (
                 <Fragment key={`row-group-${rowKey}`}>
-                  {/* Parent row with expand button */}
                   <tr
                     className={clsx(isExpanded && tableStyles.expandedRow)}
                     title={rowDimensionValue}
@@ -349,85 +489,29 @@ export const PivotTable: FC<PivotTableProps<any>> = ({
 
                     {renderMeasureCells(cellMap, String(row), `cell-${row}`)}
 
-                    {renderRowTotalCells(
-                      (_key, mi) => getMeasureTotal(rowTotals, String(row), mi, measures.length),
-                      `row-total-${String(row)}`,
+                    {renderRowAggCells(
+                      (_type, _measureKey, measureIndex) =>
+                        getAggregatedValue(
+                          rowAggs,
+                          String(row),
+                          measureIndex,
+                          _type,
+                          measures.length,
+                        ),
+                      rowAggs.get(String(row)) ?? grandAggs,
+                      `row-agg-${String(row)}`,
                     )}
                   </tr>
 
-                  {/* Sub-rows when expanded and loaded */}
                   {showSubRows && renderSubRows(rowKey, subRows)}
                 </Fragment>
               );
             })}
-            {hasColumnTotals && (
-              <tr key="totals-row" className={tableStyles.stickyLastRow}>
-                <th
-                  scope="row"
-                  className={clsx(tableStyles.stickyFirstColumn, tableStyles.boltCell)}
-                  title={totalLabel}
-                  style={getTableCellWidthStyle(firstColumnWidth)}
-                >
-                  {totalLabel}
-                </th>
 
-                {columnValues.flatMap((columnValue) =>
-                  measures.map((measure, idx) => {
-                    const show = columnTotalsSet.has(String(measure.key));
-                    const mi = measureIndexByKey.get(String(measure.key)) ?? -1;
-                    const key = `col-total-${String(columnValue)}-${measure.key}-${idx}`;
-                    const value = getMeasureTotal(
-                      colTotals,
-                      String(columnValue),
-                      mi,
-                      measures.length,
-                    );
-                    let displayValue: any = value;
-
-                    if (measure.showAsPercentage) {
-                      displayValue = getPercentageDisplay(
-                        100,
-                        measure.percentageDecimalPlaces ?? 0,
-                      );
-                    } else if (measure.accessor) {
-                      displayValue = measure.accessor({ [measure.key]: value });
-                    }
-                    const columnValueDisplay = show ? displayValue : '';
-
-                    return (
-                      <td key={key} className={tableStyles.boltCell} title={columnValueDisplay}>
-                        {columnValueDisplay}
-                      </td>
-                    );
-                  }),
-                )}
-
-                {hasRowTotals &&
-                  measures
-                    .filter((measure) => rowTotalsSet.has(measure.key))
-                    .map((measure, idx) => {
-                      const measureIndex = measureIndexByKey.get(measure.key) ?? -1;
-                      const key = `grand-total-${measure.key}-${idx}`;
-                      const value: number = grandTotals[measureIndex] ?? 0;
-                      let displayValue: any = value;
-
-                      if (measure.showAsPercentage) {
-                        displayValue = getPercentageDisplay(
-                          100,
-                          measure.percentageDecimalPlaces ?? 0,
-                        );
-                      } else if (measure.accessor) {
-                        displayValue = measure.accessor({ [measure.key]: value });
-                      }
-
-                      return (
-                        <td key={key} className={tableStyles.boltCell} title={displayValue}>
-                          {displayValue}
-                        </td>
-                      );
-                    })}
-              </tr>
-            )}
+            {hasColumnAggs &&
+              columnAggregationsFor.map((group: PivotAggregationConfig<any>, gi: number) =>
+                renderColumnAggRow(group, gi, gi === columnAggregationsFor.length - 1),
+              )}
           </tbody>
         </table>
       </div>

--- a/src/components/charts/tables/PivotTable/PivotTable.tsx
+++ b/src/components/charts/tables/PivotTable/PivotTable.tsx
@@ -309,6 +309,25 @@ export const PivotTable: FC<PivotTableProps<any>> = ({
     }
   };
 
+  // Value + sum (for percentage display) of a bottom-right "corner" cell: the
+  // rowGroup-typed values down a row-total column, combined with the column-total type.
+  const getCornerCellValue = (
+    columnAggType: PivotAggregationType,
+    rowAggType: PivotAggregationType,
+    measureIndex: number,
+  ): { value: number; sum: number } => {
+    const rowTotalColumn = rowValues.map((r) =>
+      getAggregatedValue(rowAggs, String(r), measureIndex, rowAggType, measures.length),
+    );
+    const rowSumColumn = rowValues.map((r) =>
+      getAggregatedValue(rowAggs, String(r), measureIndex, 'sum', measures.length),
+    );
+    return {
+      value: aggregateValues(columnAggType, rowTotalColumn),
+      sum: aggregateValues(columnAggType, rowSumColumn),
+    };
+  };
+
   const renderColumnAggRow = (
     group: PivotAggregationConfig<any>,
     gi: number,
@@ -378,21 +397,10 @@ export const PivotTable: FC<PivotTableProps<any>> = ({
               const measureIndex = measureIndexByKey.get(measureKey) ?? -1;
               const key = `grand-agg-${group.type}-${gi}-${rowGroup.type}-${rgi}-${measureKey}-${idx}`;
 
-              const rowTotalColumn = rowValues.map((r) =>
-                getAggregatedValue(
-                  rowAggs,
-                  String(r),
-                  measureIndex,
-                  rowGroup.type,
-                  measures.length,
-                ),
-              );
-              const value = aggregateValues(group.type, rowTotalColumn);
-              const cornerSum = aggregateValues(
+              const { value, sum: cornerSum } = getCornerCellValue(
                 group.type,
-                rowValues.map((r) =>
-                  getAggregatedValue(rowAggs, String(r), measureIndex, 'sum', measures.length),
-                ),
+                rowGroup.type,
+                measureIndex,
               );
               const displayValue = measure
                 ? getColumnAggDisplayValue(rowGroup.type, value, measure, cornerSum)

--- a/src/components/charts/tables/PivotTable/PivotTable.tsx
+++ b/src/components/charts/tables/PivotTable/PivotTable.tsx
@@ -12,6 +12,7 @@ import {
   getCellDisplayValue,
   getAggregatedValue,
   getPercentageDisplay,
+  isNumber,
   usePivotAggregations,
   useProgressiveRows,
 } from './PivotTable.utils';
@@ -179,9 +180,16 @@ export const PivotTable: FC<PivotTableProps<any>> = ({
     sourceAggs: AggResult,
     measureIndex: number,
   ): any => {
-    if (type === 'sum' && measure.showAsPercentage) {
-      const denominator = sourceAggs.sum[measureIndex] || 1;
-      if (typeof denominator === 'number' && denominator > 0) {
+    if (measure.showAsPercentage) {
+      const denominator = sourceAggs.sum[measureIndex] || 0;
+      if (type === 'sum') {
+        if (typeof denominator === 'number' && denominator > 0) {
+          return getPercentageDisplay(
+            (value / denominator) * 100,
+            measure.percentageDecimalPlaces ?? 0,
+          );
+        }
+      } else if (isNumber(value) && isNumber(denominator) && denominator > 0) {
         return getPercentageDisplay(
           (value / denominator) * 100,
           measure.percentageDecimalPlaces ?? 0,
@@ -270,11 +278,35 @@ export const PivotTable: FC<PivotTableProps<any>> = ({
     type: PivotAggregationType,
     value: number,
     measure: any,
+    denominator?: number,
   ): any => {
-    if (type === 'sum' && measure.showAsPercentage) {
-      return getPercentageDisplay(100, measure.percentageDecimalPlaces ?? 0);
+    if (measure.showAsPercentage) {
+      if (type === 'sum') {
+        return getPercentageDisplay(100, measure.percentageDecimalPlaces ?? 0);
+      }
+      const denom = denominator ?? 0;
+      if (isNumber(value) && denom > 0) {
+        return getPercentageDisplay((value / denom) * 100, measure.percentageDecimalPlaces ?? 0);
+      }
     }
     return measure.accessor ? measure.accessor({ [measure.key]: value }) : value;
+  };
+
+  // Combine a list of already-computed values with a given aggregation type.
+  // Used for the bottom-right "corner" cells, where a column-total row meets a
+  // row-total column and neither raw cell values nor a single grand aggregate apply.
+  const aggregateValues = (type: PivotAggregationType, values: number[]): number => {
+    if (values.length === 0) return 0;
+    switch (type) {
+      case 'sum':
+        return values.reduce((a, b) => a + b, 0);
+      case 'min':
+        return Math.min(...values);
+      case 'max':
+        return Math.max(...values);
+      case 'average':
+        return values.reduce((a, b) => a + b, 0) / values.length;
+    }
   };
 
   const renderColumnAggRow = (
@@ -323,7 +355,14 @@ export const PivotTable: FC<PivotTableProps<any>> = ({
               group.type,
               measures.length,
             );
-            const displayValue = getColumnAggDisplayValue(group.type, value, measure);
+            const colSum = getAggregatedValue(
+              colAggs,
+              String(columnValue),
+              mi,
+              'sum',
+              measures.length,
+            );
+            const displayValue = getColumnAggDisplayValue(group.type, value, measure, colSum);
             return (
               <td key={key} className={tableStyles.boltCell} title={String(displayValue)}>
                 {displayValue}
@@ -338,9 +377,25 @@ export const PivotTable: FC<PivotTableProps<any>> = ({
               const measure = measureByKey.get(measureKey);
               const measureIndex = measureIndexByKey.get(measureKey) ?? -1;
               const key = `grand-agg-${group.type}-${gi}-${rowGroup.type}-${rgi}-${measureKey}-${idx}`;
-              const value = grandAggs[rowGroup.type][measureIndex] ?? 0;
+
+              const rowTotalColumn = rowValues.map((r) =>
+                getAggregatedValue(
+                  rowAggs,
+                  String(r),
+                  measureIndex,
+                  rowGroup.type,
+                  measures.length,
+                ),
+              );
+              const value = aggregateValues(group.type, rowTotalColumn);
+              const cornerSum = aggregateValues(
+                group.type,
+                rowValues.map((r) =>
+                  getAggregatedValue(rowAggs, String(r), measureIndex, 'sum', measures.length),
+                ),
+              );
               const displayValue = measure
-                ? getColumnAggDisplayValue(rowGroup.type, value, measure)
+                ? getColumnAggDisplayValue(rowGroup.type, value, measure, cornerSum)
                 : value;
               return (
                 <td key={key} className={tableStyles.boltCell} title={String(displayValue)}>

--- a/src/components/charts/tables/PivotTable/PivotTable.types.tsx
+++ b/src/components/charts/tables/PivotTable/PivotTable.types.tsx
@@ -9,8 +9,7 @@ export const PivotAggregationType = {
   AVERAGE: 'average',
 } as const;
 
-export type PivotAggregationType =
-  (typeof PivotAggregationType)[keyof typeof PivotAggregationType];
+export type PivotAggregationType = (typeof PivotAggregationType)[keyof typeof PivotAggregationType];
 
 /** @internal Used by the component to drive header/cell rendering in a consistent order. */
 export type PivotAggregationConfig<T> = {

--- a/src/components/charts/tables/PivotTable/PivotTable.types.tsx
+++ b/src/components/charts/tables/PivotTable/PivotTable.types.tsx
@@ -2,6 +2,22 @@
 
 import { ReactElement } from 'react';
 
+export const PivotAggregationType = {
+  SUM: 'sum',
+  MIN: 'min',
+  MAX: 'max',
+  AVERAGE: 'average',
+} as const;
+
+export type PivotAggregationType =
+  (typeof PivotAggregationType)[keyof typeof PivotAggregationType];
+
+/** @internal Used by the component to drive header/cell rendering in a consistent order. */
+export type PivotAggregationConfig<T> = {
+  type: PivotAggregationType;
+  measureKeys: Array<Extract<keyof T, string>>;
+};
+
 export type PivotTablePropsMeasure<T> = {
   key: Extract<keyof T, string>;
   label: string;
@@ -23,6 +39,8 @@ export type PivotTablePropsColumnDimension<T> = {
   formatValue?: (value: any) => any;
 };
 
+type MeasureKeys<T> = Array<Extract<keyof T, string>>;
+
 export type PivotTableProps<T> = {
   data: T[];
   measures: PivotTablePropsMeasure<T>[];
@@ -31,10 +49,18 @@ export type PivotTableProps<T> = {
   progressive?: boolean;
   batchSize?: number;
   batchDelayMs?: number;
-  rowTotalsFor?: Array<Extract<keyof T, string>>;
-  columnTotalsFor?: Array<Extract<keyof T, string>>;
-  showColumnPercentages?: boolean;
-  totalLabel?: string;
+  rowSumFor?: MeasureKeys<T>;
+  rowMinFor?: MeasureKeys<T>;
+  rowMaxFor?: MeasureKeys<T>;
+  rowAverageFor?: MeasureKeys<T>;
+  columnSumFor?: MeasureKeys<T>;
+  columnMinFor?: MeasureKeys<T>;
+  columnMaxFor?: MeasureKeys<T>;
+  columnAverageFor?: MeasureKeys<T>;
+  sumLabel?: string;
+  minLabel?: string;
+  maxLabel?: string;
+  averageLabel?: string;
   percentageDecimalPlaces?: number;
   columnWidth?: number;
   firstColumnWidth?: number;

--- a/src/components/charts/tables/PivotTable/PivotTable.utils.test.ts
+++ b/src/components/charts/tables/PivotTable/PivotTable.utils.test.ts
@@ -4,10 +4,12 @@ import {
   isNumber,
   getPercentageDisplay,
   buildCellMap,
-  getMeasureTotal,
-  computeSubRowTotal,
+  getAggregatedValue,
+  computeSubRowAggregation,
   getCellDisplayValue,
   useProgressiveRows,
+  usePivotAggregations,
+  AGG_DEFAULT_LABELS,
 } from './PivotTable.utils';
 
 describe('isNumber', () => {
@@ -103,35 +105,60 @@ describe('buildCellMap', () => {
   });
 });
 
-describe('getMeasureTotal', () => {
-  it('retrieves the correct total for a given key and measure index', () => {
-    const totalsMap = new Map([['North', [100, 200, 300]]]);
-
-    expect(getMeasureTotal(totalsMap, 'North', 0, 3)).toBe(100);
-    expect(getMeasureTotal(totalsMap, 'North', 1, 3)).toBe(200);
-    expect(getMeasureTotal(totalsMap, 'North', 2, 3)).toBe(300);
-  });
-
-  it('returns 0 when key is not in the map', () => {
-    const totalsMap = new Map<string, number[]>();
-
-    expect(getMeasureTotal(totalsMap, 'Missing', 0, 2)).toBe(0);
-  });
-
-  it('returns 0 when measureIndex is negative', () => {
-    const totalsMap = new Map([['North', [100]]]);
-
-    expect(getMeasureTotal(totalsMap, 'North', -1, 1)).toBe(0);
-  });
-
-  it('returns 0 when measureIndex exceeds the array length', () => {
-    const totalsMap = new Map([['North', [100]]]);
-
-    expect(getMeasureTotal(totalsMap, 'North', 5, 2)).toBe(0);
+describe('AGG_DEFAULT_LABELS', () => {
+  it('provides a human-readable label for each aggregation type', () => {
+    expect(AGG_DEFAULT_LABELS.sum).toBe('Sum');
+    expect(AGG_DEFAULT_LABELS.min).toBe('Min');
+    expect(AGG_DEFAULT_LABELS.max).toBe('Max');
+    expect(AGG_DEFAULT_LABELS.average).toBe('Average');
   });
 });
 
-describe('computeSubRowTotal', () => {
+describe('getAggregatedValue', () => {
+  const makeResult = (sum: number, min: number, max: number, average: number) => ({
+    sum: [sum],
+    min: [min],
+    max: [max],
+    average: [average],
+  });
+
+  it('retrieves sum for a given key and measure index', () => {
+    const aggsMap = new Map([['North', makeResult(300, 100, 200, 150)]]);
+    expect(getAggregatedValue(aggsMap, 'North', 0, 'sum', 1)).toBe(300);
+  });
+
+  it('retrieves min correctly', () => {
+    const aggsMap = new Map([['North', makeResult(300, 100, 200, 150)]]);
+    expect(getAggregatedValue(aggsMap, 'North', 0, 'min', 1)).toBe(100);
+  });
+
+  it('retrieves max correctly', () => {
+    const aggsMap = new Map([['North', makeResult(300, 100, 200, 150)]]);
+    expect(getAggregatedValue(aggsMap, 'North', 0, 'max', 1)).toBe(200);
+  });
+
+  it('retrieves average correctly', () => {
+    const aggsMap = new Map([['North', makeResult(300, 100, 200, 150)]]);
+    expect(getAggregatedValue(aggsMap, 'North', 0, 'average', 1)).toBe(150);
+  });
+
+  it('returns 0 when key is not in the map', () => {
+    const aggsMap = new Map<string, ReturnType<typeof makeResult>>();
+    expect(getAggregatedValue(aggsMap, 'Missing', 0, 'sum', 1)).toBe(0);
+  });
+
+  it('returns 0 when measureIndex is negative', () => {
+    const aggsMap = new Map([['North', makeResult(300, 100, 200, 150)]]);
+    expect(getAggregatedValue(aggsMap, 'North', -1, 'sum', 1)).toBe(0);
+  });
+
+  it('returns 0 when measureIndex exceeds array length', () => {
+    const aggsMap = new Map([['North', makeResult(300, 100, 200, 150)]]);
+    expect(getAggregatedValue(aggsMap, 'North', 5, 'sum', 1)).toBe(0);
+  });
+});
+
+describe('computeSubRowAggregation', () => {
   const cellMap = new Map([
     [
       'North',
@@ -143,19 +170,31 @@ describe('computeSubRowTotal', () => {
     ],
   ]);
 
-  it('sums numeric values across column values for a row key', () => {
-    expect(computeSubRowTotal(cellMap, 'North', ['Q1', 'Q2', 'Q3'], 'sales')).toBe(450);
+  it('sums values across column values for a row key', () => {
+    expect(computeSubRowAggregation(cellMap, 'North', ['Q1', 'Q2', 'Q3'], 'sales', 'sum')).toBe(450);
+  });
+
+  it('returns the minimum value across column values', () => {
+    expect(computeSubRowAggregation(cellMap, 'North', ['Q1', 'Q2', 'Q3'], 'sales', 'min')).toBe(100);
+  });
+
+  it('returns the maximum value across column values', () => {
+    expect(computeSubRowAggregation(cellMap, 'North', ['Q1', 'Q2', 'Q3'], 'sales', 'max')).toBe(200);
+  });
+
+  it('returns the average of values across column values', () => {
+    expect(computeSubRowAggregation(cellMap, 'North', ['Q1', 'Q2', 'Q3'], 'sales', 'average')).toBe(150);
   });
 
   it('sums only the specified columns', () => {
-    expect(computeSubRowTotal(cellMap, 'North', ['Q1', 'Q2'], 'sales')).toBe(300);
+    expect(computeSubRowAggregation(cellMap, 'North', ['Q1', 'Q2'], 'sales', 'sum')).toBe(300);
   });
 
   it('returns 0 for a row key not in the map', () => {
-    expect(computeSubRowTotal(cellMap, 'South', ['Q1', 'Q2'], 'sales')).toBe(0);
+    expect(computeSubRowAggregation(cellMap, 'South', ['Q1', 'Q2'], 'sales', 'sum')).toBe(0);
   });
 
-  it('skips NaN values in the sum', () => {
+  it('skips NaN values in the computation', () => {
     const mapWithNaN = new Map([
       [
         'East',
@@ -166,7 +205,104 @@ describe('computeSubRowTotal', () => {
       ],
     ]);
 
-    expect(computeSubRowTotal(mapWithNaN, 'East', ['Q1', 'Q2'], 'sales')).toBe(100);
+    expect(computeSubRowAggregation(mapWithNaN, 'East', ['Q1', 'Q2'], 'sales', 'sum')).toBe(100);
+    expect(computeSubRowAggregation(mapWithNaN, 'East', ['Q1', 'Q2'], 'sales', 'min')).toBe(100);
+    expect(computeSubRowAggregation(mapWithNaN, 'East', ['Q1', 'Q2'], 'sales', 'max')).toBe(100);
+    expect(computeSubRowAggregation(mapWithNaN, 'East', ['Q1', 'Q2'], 'sales', 'average')).toBe(100);
+  });
+});
+
+describe('usePivotAggregations', () => {
+  const data = [
+    { country: 'US', month: 'Jan', revenue: 100 },
+    { country: 'US', month: 'Feb', revenue: 120 },
+    { country: 'UK', month: 'Jan', revenue: 80 },
+    { country: 'UK', month: 'Feb', revenue: 90 },
+  ];
+  const measures = [{ key: 'revenue' as const, label: 'Revenue' }];
+  const rowKey = 'country';
+  const colKey = 'month';
+  const columnValues = ['Jan', 'Feb'];
+  const rowValues = ['US', 'UK'];
+
+  it('computes row sums correctly', () => {
+    const { result } = renderHook(() =>
+      usePivotAggregations(data, measures, rowKey, colKey, columnValues, rowValues),
+    );
+
+    expect(result.current.rowAggs.get('US')?.sum[0]).toBe(220);
+    expect(result.current.rowAggs.get('UK')?.sum[0]).toBe(170);
+  });
+
+  it('computes column sums correctly', () => {
+    const { result } = renderHook(() =>
+      usePivotAggregations(data, measures, rowKey, colKey, columnValues, rowValues),
+    );
+
+    expect(result.current.colAggs.get('Jan')?.sum[0]).toBe(180);
+    expect(result.current.colAggs.get('Feb')?.sum[0]).toBe(210);
+  });
+
+  it('computes grand sum correctly', () => {
+    const { result } = renderHook(() =>
+      usePivotAggregations(data, measures, rowKey, colKey, columnValues, rowValues),
+    );
+
+    expect(result.current.grandAggs.sum[0]).toBe(390);
+  });
+
+  it('computes row min correctly', () => {
+    const { result } = renderHook(() =>
+      usePivotAggregations(data, measures, rowKey, colKey, columnValues, rowValues),
+    );
+
+    expect(result.current.rowAggs.get('US')?.min[0]).toBe(100);
+    expect(result.current.rowAggs.get('UK')?.min[0]).toBe(80);
+  });
+
+  it('computes row max correctly', () => {
+    const { result } = renderHook(() =>
+      usePivotAggregations(data, measures, rowKey, colKey, columnValues, rowValues),
+    );
+
+    expect(result.current.rowAggs.get('US')?.max[0]).toBe(120);
+    expect(result.current.rowAggs.get('UK')?.max[0]).toBe(90);
+  });
+
+  it('computes row average correctly', () => {
+    const { result } = renderHook(() =>
+      usePivotAggregations(data, measures, rowKey, colKey, columnValues, rowValues),
+    );
+
+    expect(result.current.rowAggs.get('US')?.average[0]).toBe(110);
+    expect(result.current.rowAggs.get('UK')?.average[0]).toBe(85);
+  });
+
+  it('computes grand average correctly', () => {
+    const { result } = renderHook(() =>
+      usePivotAggregations(data, measures, rowKey, colKey, columnValues, rowValues),
+    );
+
+    expect(result.current.grandAggs.average[0]).toBe(97.5);
+  });
+
+  it('initialises missing row keys with zero values', () => {
+    const { result } = renderHook(() =>
+      usePivotAggregations([], measures, rowKey, colKey, columnValues, ['FR']),
+    );
+
+    expect(result.current.rowAggs.get('FR')?.sum[0]).toBe(0);
+    expect(result.current.rowAggs.get('FR')?.min[0]).toBe(0);
+    expect(result.current.rowAggs.get('FR')?.max[0]).toBe(0);
+    expect(result.current.rowAggs.get('FR')?.average[0]).toBe(0);
+  });
+
+  it('initialises missing column keys with zero values', () => {
+    const { result } = renderHook(() =>
+      usePivotAggregations([], measures, rowKey, colKey, ['Mar'], rowValues),
+    );
+
+    expect(result.current.colAggs.get('Mar')?.sum[0]).toBe(0);
   });
 });
 

--- a/src/components/charts/tables/PivotTable/PivotTable.utils.test.ts
+++ b/src/components/charts/tables/PivotTable/PivotTable.utils.test.ts
@@ -171,19 +171,27 @@ describe('computeSubRowAggregation', () => {
   ]);
 
   it('sums values across column values for a row key', () => {
-    expect(computeSubRowAggregation(cellMap, 'North', ['Q1', 'Q2', 'Q3'], 'sales', 'sum')).toBe(450);
+    expect(computeSubRowAggregation(cellMap, 'North', ['Q1', 'Q2', 'Q3'], 'sales', 'sum')).toBe(
+      450,
+    );
   });
 
   it('returns the minimum value across column values', () => {
-    expect(computeSubRowAggregation(cellMap, 'North', ['Q1', 'Q2', 'Q3'], 'sales', 'min')).toBe(100);
+    expect(computeSubRowAggregation(cellMap, 'North', ['Q1', 'Q2', 'Q3'], 'sales', 'min')).toBe(
+      100,
+    );
   });
 
   it('returns the maximum value across column values', () => {
-    expect(computeSubRowAggregation(cellMap, 'North', ['Q1', 'Q2', 'Q3'], 'sales', 'max')).toBe(200);
+    expect(computeSubRowAggregation(cellMap, 'North', ['Q1', 'Q2', 'Q3'], 'sales', 'max')).toBe(
+      200,
+    );
   });
 
   it('returns the average of values across column values', () => {
-    expect(computeSubRowAggregation(cellMap, 'North', ['Q1', 'Q2', 'Q3'], 'sales', 'average')).toBe(150);
+    expect(computeSubRowAggregation(cellMap, 'North', ['Q1', 'Q2', 'Q3'], 'sales', 'average')).toBe(
+      150,
+    );
   });
 
   it('sums only the specified columns', () => {
@@ -208,7 +216,9 @@ describe('computeSubRowAggregation', () => {
     expect(computeSubRowAggregation(mapWithNaN, 'East', ['Q1', 'Q2'], 'sales', 'sum')).toBe(100);
     expect(computeSubRowAggregation(mapWithNaN, 'East', ['Q1', 'Q2'], 'sales', 'min')).toBe(100);
     expect(computeSubRowAggregation(mapWithNaN, 'East', ['Q1', 'Q2'], 'sales', 'max')).toBe(100);
-    expect(computeSubRowAggregation(mapWithNaN, 'East', ['Q1', 'Q2'], 'sales', 'average')).toBe(100);
+    expect(computeSubRowAggregation(mapWithNaN, 'East', ['Q1', 'Q2'], 'sales', 'average')).toBe(
+      100,
+    );
   });
 });
 

--- a/src/components/charts/tables/PivotTable/PivotTable.utils.ts
+++ b/src/components/charts/tables/PivotTable/PivotTable.utils.ts
@@ -1,5 +1,5 @@
 import { useEffect, useMemo, useState } from 'react';
-import { PivotTablePropsMeasure } from './PivotTable.types';
+import { PivotAggregationType, PivotTablePropsMeasure } from './PivotTable.types';
 
 /* eslint-disable @typescript-eslint/no-explicit-any */
 
@@ -41,29 +41,138 @@ export const buildCellMap = (
   return map;
 };
 
-export const getMeasureTotal = (
-  totalsMap: Map<string, number[]>,
-  key: string,
-  measureIndex: number,
-  measuresCount: number,
-): number => {
-  const totals = totalsMap.get(key) ?? Array(measuresCount).fill(0);
-  return measureIndex >= 0 ? (totals[measureIndex] ?? 0) : 0;
+export const AGG_DEFAULT_LABELS: Record<PivotAggregationType, string> = {
+  sum: 'Sum',
+  min: 'Min',
+  max: 'Max',
+  average: 'Average',
 };
 
-export const computeSubRowTotal = (
+export type AggResult = {
+  sum: number[];
+  min: number[];
+  max: number[];
+  average: number[];
+};
+
+type AggAccumulator = {
+  sum: number[];
+  count: number[];
+  min: number[];
+  max: number[];
+};
+
+const makeAccumulator = (len: number): AggAccumulator => ({
+  sum: new Array(len).fill(0),
+  count: new Array(len).fill(0),
+  min: new Array(len).fill(Infinity),
+  max: new Array(len).fill(-Infinity),
+});
+
+const finaliseAccumulator = (acc: AggAccumulator): AggResult => ({
+  sum: acc.sum,
+  min: acc.min.map((v) => (v === Infinity ? 0 : v)),
+  max: acc.max.map((v) => (v === -Infinity ? 0 : v)),
+  average: acc.sum.map((s, i) => (acc.count[i]! > 0 ? s / acc.count[i]! : 0)),
+});
+
+export const getAggregatedValue = (
+  aggsMap: Map<string, AggResult>,
+  key: string,
+  measureIndex: number,
+  type: PivotAggregationType,
+  measuresCount: number,
+): number => {
+  const result = aggsMap.get(key);
+  if (!result) return 0;
+  const arr = result[type];
+  return measureIndex >= 0 && measureIndex < measuresCount ? (arr[measureIndex] ?? 0) : 0;
+};
+
+export const computeSubRowAggregation = (
   cellMap: Map<string, Map<string, Record<string, any>>>,
   rowKey: string,
   columnValues: string[],
   measureKey: string,
+  type: PivotAggregationType,
 ): number => {
-  let total = 0;
+  const values: number[] = [];
   for (const columnValue of columnValues) {
     const data = cellMap.get(rowKey)?.get(String(columnValue)) ?? {};
     const val = Number(data?.[measureKey]);
-    if (!Number.isNaN(val)) total += val;
+    if (!Number.isNaN(val)) values.push(val);
   }
-  return total;
+  if (values.length === 0) return 0;
+  switch (type) {
+    case 'sum':
+      return values.reduce((a, b) => a + b, 0);
+    case 'min':
+      return Math.min(...values);
+    case 'max':
+      return Math.max(...values);
+    case 'average':
+      return values.reduce((a, b) => a + b, 0) / values.length;
+  }
+};
+
+export const usePivotAggregations = (
+  data: any[],
+  measures: PivotTablePropsMeasure<any>[],
+  rowDimensionKey: string,
+  columnDimensionKey: string,
+  columnValues: string[],
+  rowValues: string[],
+) => {
+  return useMemo(() => {
+    const cAccs = new Map<string, AggAccumulator>();
+    const rAccs = new Map<string, AggAccumulator>();
+    const gAcc = makeAccumulator(measures.length);
+
+    for (const d of data) {
+      const r = String(d[rowDimensionKey]);
+      const c = String(d[columnDimensionKey]);
+
+      if (!cAccs.has(c)) cAccs.set(c, makeAccumulator(measures.length));
+      if (!rAccs.has(r)) rAccs.set(r, makeAccumulator(measures.length));
+
+      const cAcc = cAccs.get(c)!;
+      const rAcc = rAccs.get(r)!;
+
+      measures.forEach((m, i) => {
+        const v = Number((d as any)?.[m.key]);
+        if (!Number.isNaN(v)) {
+          cAcc.sum[i]! += v;
+          cAcc.count[i]!++;
+          cAcc.min[i] = Math.min(cAcc.min[i]!, v);
+          cAcc.max[i] = Math.max(cAcc.max[i]!, v);
+
+          rAcc.sum[i]! += v;
+          rAcc.count[i]!++;
+          rAcc.min[i] = Math.min(rAcc.min[i]!, v);
+          rAcc.max[i] = Math.max(rAcc.max[i]!, v);
+
+          gAcc.sum[i]! += v;
+          gAcc.count[i]!++;
+          gAcc.min[i] = Math.min(gAcc.min[i]!, v);
+          gAcc.max[i] = Math.max(gAcc.max[i]!, v);
+        }
+      });
+    }
+
+    for (const c of columnValues) {
+      if (!cAccs.has(String(c))) cAccs.set(String(c), makeAccumulator(measures.length));
+    }
+    for (const r of rowValues) {
+      if (!rAccs.has(String(r))) rAccs.set(String(r), makeAccumulator(measures.length));
+    }
+
+    const colAggs = new Map<string, AggResult>();
+    const rowAggs = new Map<string, AggResult>();
+    cAccs.forEach((acc, key) => colAggs.set(key, finaliseAccumulator(acc)));
+    rAccs.forEach((acc, key) => rowAggs.set(key, finaliseAccumulator(acc)));
+
+    return { colAggs, rowAggs, grandAggs: finaliseAccumulator(gAcc) };
+  }, [data, measures, rowDimensionKey, columnDimensionKey, columnValues, rowValues]);
 };
 
 export const useProgressiveRows = (
@@ -108,56 +217,4 @@ export const useProgressiveRows = (
   }, [progressive, batchSize, batchDelayMs, rowValues.length]);
 
   return progressive ? rowValues.slice(0, visibleCount) : rowValues;
-};
-
-export const usePivotTotals = (
-  data: any[],
-  measures: PivotTablePropsMeasure<any>[],
-  rowDimensionKey: string,
-  columnDimensionKey: string,
-  columnValues: string[],
-  rowValues: string[],
-) => {
-  return useMemo(() => {
-    const cTotals = new Map<string, number[]>();
-    const rTotals = new Map<string, number[]>();
-    const gTotals = measures.map(() => 0);
-
-    for (const d of data) {
-      const r = String(d[rowDimensionKey]);
-      const c = String(d[columnDimensionKey]);
-      const cArr = cTotals.get(c) ?? measures.map(() => 0);
-      const rArr = rTotals.get(r) ?? measures.map(() => 0);
-
-      measures.forEach((m, i) => {
-        const raw = (d as any)?.[m.key];
-        const v = Number(raw);
-        if (!Number.isNaN(v)) {
-          cArr[i]! += v;
-          rArr[i]! += v;
-          gTotals[i]! += v;
-        }
-      });
-
-      cTotals.set(c, cArr);
-      rTotals.set(r, rArr);
-    }
-
-    for (const c of columnValues) {
-      if (!cTotals.has(String(c)))
-        cTotals.set(
-          String(c),
-          measures.map(() => 0),
-        );
-    }
-    for (const r of rowValues) {
-      if (!rTotals.has(String(r)))
-        rTotals.set(
-          String(r),
-          measures.map(() => 0),
-        );
-    }
-
-    return { colTotals: cTotals, rowTotals: rTotals, grandTotals: gTotals };
-  }, [data, measures, rowDimensionKey, columnDimensionKey, columnValues, rowValues]);
 };

--- a/src/components/charts/tables/PivotTable/PivotTable.utils.ts
+++ b/src/components/charts/tables/PivotTable/PivotTable.utils.ts
@@ -99,7 +99,8 @@ export const computeSubRowAggregation = (
   const values: number[] = [];
   for (const columnValue of columnValues) {
     const data = cellMap.get(rowKey)?.get(String(columnValue)) ?? {};
-    const val = Number(data?.[measureKey]);
+    const raw = data?.[measureKey];
+    const val = raw == null ? NaN : Number(raw);
     if (!Number.isNaN(val)) values.push(val);
   }
   if (values.length === 0) return 0;
@@ -139,7 +140,8 @@ export const usePivotAggregations = (
       const rAcc = rAccs.get(r)!;
 
       measures.forEach((m, i) => {
-        const v = Number((d as any)?.[m.key]);
+        const raw = (d as any)?.[m.key];
+        const v = raw == null ? NaN : Number(raw);
         if (!Number.isNaN(v)) {
           cAcc.sum[i]! += v;
           cAcc.count[i]!++;
@@ -189,32 +191,23 @@ export const useProgressiveRows = (
     progressive ? Math.min(batchSize, rowValues.length) : rowValues.length,
   );
 
+  // Reset count when the data length or progressive flag changes.
   useEffect(() => {
-    if (!progressive) {
-      setVisibleCount(rowValues.length);
-      return;
-    }
-    let cancelled = false;
-    let t: number | null = null;
-    setVisibleCount(Math.min(batchSize, rowValues.length));
+    setVisibleCount(progressive ? Math.min(batchSize, rowValues.length) : rowValues.length);
+  }, [progressive, batchSize, rowValues.length]);
 
-    const tick = () => {
-      setVisibleCount((prev) => {
-        const next = Math.min(prev + batchSize, rowValues.length);
-        if (next < rowValues.length && !cancelled) {
-          t = window.setTimeout(tick, batchDelayMs);
-        }
-        return next;
-      });
-    };
+  // Schedule the next batch only when more rows are waiting.
+  // Keeps setTimeout out of the state updater so it isn't called multiple
+  // times if React replays the updater in concurrent mode.
+  useEffect(() => {
+    if (!progressive || visibleCount >= rowValues.length) return;
 
-    t = window.setTimeout(tick, batchDelayMs);
+    const t = window.setTimeout(() => {
+      setVisibleCount((prev) => Math.min(prev + batchSize, rowValues.length));
+    }, batchDelayMs);
 
-    return () => {
-      cancelled = true;
-      if (t !== null) window.clearTimeout(t);
-    };
-  }, [progressive, batchSize, batchDelayMs, rowValues.length]);
+    return () => window.clearTimeout(t);
+  }, [progressive, visibleCount, rowValues.length, batchSize, batchDelayMs]);
 
   return progressive ? rowValues.slice(0, visibleCount) : rowValues;
 };


### PR DESCRIPTION
# Why is this pull-request needed?

The pivot table's totals were limited to a single boolean sum per row/column, with a hardcoded "Total" label. remarkable-pro needs to let users choose which aggregations (sum, min, max, average) to show per axis, with customizable/translatable labels — and when several are shown at once, every aggregation row needs to stay pinned, not just the last one.

# Main changes

- Replaced `rowTotalsFor` / `columnTotalsFor` on `PivotTable` with per-aggregation props: `rowSumFor`, `rowMinFor`, `rowMaxFor`, `rowAverageFor`, `columnSumFor`, `columnMinFor`, `columnMaxFor`, `columnAverageFor`
- Added `sumLabel` / `minLabel` / `maxLabel` / `averageLabel` props (defaulting to `AGG_DEFAULT_LABELS`) so aggregation row/column labels can be customised or translated
- Added `PivotAggregationType` and `PivotAggregationConfig<T>` types, and reworked the aggregation computation (`AggResult`, `computeSubRowAggregation`, etc.) to support multiple simultaneous aggregations instead of a single total
- Fixed sticky positioning so when multiple aggregation rows are shown together, all of them stack and stay pinned at the bottom instead of only the final one
- Added `onCellClick` to `HeatMap` (type + implementation), which was already wired up in `HeatMapPro` on `remarkable-pro` but missing from the UI library
- 
# Test evidence

https://github.com/user-attachments/assets/b5fd1336-cf63-40d0-bd0a-27eb2307982a



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Pivot table aggregations now support Sum, Min, Max, and Average for rows and columns.
  * Multiple aggregation rows can appear together and stay sticky at the bottom.
  * Heat maps can now respond to cell clicks, with clickable cursor feedback.

* **Bug Fixes**
  * Aggregated values and labels now render consistently across table views, including custom labels.
  * Expanded rows and summary rows now follow the updated aggregation behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->