### PR TITLE
RUI-000: Add select all / deselect all option to MultiSelectField

### DIFF
--- a/.changeset/tall-drinks-refuse.md
+++ b/.changeset/tall-drinks-refuse.md
@@ -1,0 +1,5 @@
+---
+'@embeddable.com/remarkable-ui': minor
+---
+
+Add optional select all / deselect all option to MultiSelectField

--- a/src/components/editors/selects/MultiSelectField/MultiSelectField.stories.tsx
+++ b/src/components/editors/selects/MultiSelectField/MultiSelectField.stories.tsx
@@ -225,6 +225,28 @@ export const Searchable: Story = {
   },
 };
 
+export const WithSelectAll: Story = {
+  args: {
+    label: undefined,
+    required: false,
+    isSearchable: true,
+    showSelectAll: true,
+  },
+  render: (args) => {
+    const [, updateArgs] = useArgs();
+
+    return (
+      <MultiSelectField
+        {...args}
+        onChange={(values) => {
+          updateArgs({ values });
+          args.onChange?.(values);
+        }}
+      />
+    );
+  },
+};
+
 export const WithCategories: Story = {
   args: {
     label: undefined,

--- a/src/components/editors/selects/MultiSelectField/MultiSelectField.test.tsx
+++ b/src/components/editors/selects/MultiSelectField/MultiSelectField.test.tsx
@@ -404,4 +404,180 @@ describe('MultiSelectField', () => {
       expect(handlePendingChange).toHaveBeenCalledWith([]);
     });
   });
+
+  describe('select all', () => {
+    it('does not render the select all option by default', async () => {
+      const user = userEvent.setup();
+      render(<MultiSelectField options={OPTIONS} onChange={vi.fn()} />);
+
+      await openDropdown(user);
+
+      expect(screen.queryByText('Select all')).not.toBeInTheDocument();
+    });
+
+    it('renders the select all option when showSelectAll is true', async () => {
+      const user = userEvent.setup();
+      render(<MultiSelectField options={OPTIONS} showSelectAll onChange={vi.fn()} />);
+
+      await openDropdown(user);
+
+      expect(screen.getByText('Select all')).toBeInTheDocument();
+    });
+
+    it('does not render the select all option when there are no options', async () => {
+      const user = userEvent.setup();
+      render(<MultiSelectField options={[]} showSelectAll onChange={vi.fn()} />);
+
+      await openDropdown(user);
+
+      expect(screen.queryByText('Select all')).not.toBeInTheDocument();
+    });
+
+    it('renders custom select all and deselect all labels', async () => {
+      const user = userEvent.setup();
+      render(
+        <MultiSelectField
+          options={OPTIONS}
+          showSelectAll
+          selectAllLabel="Alle auswählen"
+          onChange={vi.fn()}
+        />,
+      );
+
+      await openDropdown(user);
+
+      expect(screen.getByText('Alle auswählen')).toBeInTheDocument();
+    });
+
+    it('selects all options when select all is clicked', async () => {
+      const user = userEvent.setup();
+      const handleChange = vi.fn();
+      render(<MultiSelectField options={OPTIONS} showSelectAll onChange={handleChange} />);
+
+      await openDropdown(user);
+      await user.click(screen.getByText('Select all'));
+      await user.click(screen.getByRole('button', { name: 'Apply' }));
+
+      expect(handleChange).toHaveBeenCalledWith(['apple', 'banana', 'cherry']);
+    });
+
+    it('shows the select all label when only some options are selected', async () => {
+      const user = userEvent.setup();
+      render(
+        <MultiSelectField options={OPTIONS} values={['apple']} showSelectAll onChange={vi.fn()} />,
+      );
+
+      await openDropdown(user);
+
+      expect(screen.getByText('Select all')).toBeInTheDocument();
+    });
+
+    it('shows the deselect all label when all options are selected', async () => {
+      const user = userEvent.setup();
+      render(
+        <MultiSelectField
+          options={OPTIONS}
+          values={['apple', 'banana', 'cherry']}
+          showSelectAll
+          onChange={vi.fn()}
+        />,
+      );
+
+      await openDropdown(user);
+
+      expect(screen.getByText('Deselect all')).toBeInTheDocument();
+    });
+
+    it('deselects all options when deselect all is clicked', async () => {
+      const user = userEvent.setup();
+      const handleChange = vi.fn();
+      render(
+        <MultiSelectField
+          options={OPTIONS}
+          values={['apple', 'banana', 'cherry']}
+          showSelectAll
+          onChange={handleChange}
+        />,
+      );
+
+      await openDropdown(user);
+      await user.click(screen.getByText('Deselect all'));
+      await user.click(screen.getByRole('button', { name: 'Apply' }));
+
+      expect(handleChange).toHaveBeenCalledWith([]);
+    });
+
+    it('only selects the options matching the current search', async () => {
+      const user = userEvent.setup();
+      const handleChange = vi.fn();
+      render(
+        <MultiSelectField options={OPTIONS} showSelectAll isSearchable onChange={handleChange} />,
+      );
+
+      await openDropdown(user);
+      await user.type(screen.getByRole('searchbox'), 'app');
+      await user.click(screen.getByText('Select all'));
+      await user.click(screen.getByRole('button', { name: 'Apply' }));
+
+      expect(handleChange).toHaveBeenCalledWith(['apple']);
+    });
+
+    it('keeps selections outside the current search when deselecting all', async () => {
+      const user = userEvent.setup();
+      const handleChange = vi.fn();
+      render(
+        <MultiSelectField
+          options={OPTIONS}
+          values={['apple', 'banana']}
+          showSelectAll
+          isSearchable
+          onChange={handleChange}
+        />,
+      );
+
+      await openDropdown(user);
+      await user.type(screen.getByRole('searchbox'), 'app');
+      await user.click(screen.getByText('Deselect all'));
+      await user.click(screen.getByRole('button', { name: 'Apply' }));
+
+      expect(handleChange).toHaveBeenCalledWith(['banana']);
+    });
+
+    it('does not add duplicate values when options share the same value', async () => {
+      const user = userEvent.setup();
+      const handleChange = vi.fn();
+      render(
+        <MultiSelectField
+          options={[...OPTIONS, { value: 'apple', label: 'Apple (again)' }]}
+          showSelectAll
+          onChange={handleChange}
+        />,
+      );
+
+      await openDropdown(user);
+      await user.click(screen.getByText('Select all'));
+      await user.click(screen.getByRole('button', { name: 'Apply' }));
+
+      expect(handleChange).toHaveBeenCalledWith(['apple', 'banana', 'cherry']);
+    });
+
+    it('calls onPendingChange with all values when select all is clicked', async () => {
+      const user = userEvent.setup();
+      const handlePendingChange = vi.fn();
+      render(
+        <MultiSelectField
+          options={OPTIONS}
+          showSelectAll
+          onPendingChange={handlePendingChange}
+          onChange={vi.fn()}
+        />,
+      );
+
+      await openDropdown(user);
+      handlePendingChange.mockClear();
+      await user.click(screen.getByText('Select all'));
+
+      expect(handlePendingChange).toHaveBeenCalledWith(['apple', 'banana', 'cherry']);
+    });
+  });
 });

--- a/src/components/editors/selects/MultiSelectField/MultiSelectField.tsx
+++ b/src/components/editors/selects/MultiSelectField/MultiSelectField.tsx
@@ -11,8 +11,15 @@ import {
   SelectFieldContentList,
 } from '../shared/SelectFieldContent/SelectFieldContent';
 import { groupOptionsByCategory } from '../shared/SelectFieldContent/SelectFieldContent.utils';
-import { IconProps, IconSearch, IconSquare, IconSquareCheckFilled } from '@tabler/icons-react';
+import {
+  IconProps,
+  IconSearch,
+  IconSquare,
+  IconSquareCheckFilled,
+  IconSquareMinus,
+} from '@tabler/icons-react';
 import { Button } from '../../../shared/Button/Button';
+import { Divider } from '../../../shared/Divider/Divider';
 import styles from '../selects.module.css';
 import { useSelectSearchFocus } from '../shared/useSelectSearchFocus.hook';
 import { SelectFieldCategory } from '../shared/SelectFieldContent/SelectFieldOptions/SelectFieldCategory/SelectFieldCategory';
@@ -32,6 +39,9 @@ export type MultiSelectFieldProps<T extends SelectOptionValue> = {
   noOptionsMessage?: string;
   options: (SelectListOptionProps<T> | SelectListOptionPropsWithCategory<T>)[];
   placeholder?: string;
+  showSelectAll?: boolean;
+  selectAllLabel?: string;
+  deselectAllLabel?: string;
   submitLabel?: string;
   values?: T[];
   avoidCollisions?: boolean;
@@ -55,6 +65,9 @@ export function MultiSelectField<T extends SelectOptionValue>({
   noOptionsMessage,
   options,
   placeholder,
+  showSelectAll,
+  selectAllLabel = 'Select all',
+  deselectAllLabel = 'Deselect all',
   submitLabel = 'Apply',
   values = [],
   avoidCollisions,
@@ -107,6 +120,19 @@ export function MultiSelectField<T extends SelectOptionValue>({
 
   const groupedOptions = useMemo(() => groupOptionsByCategory(displayOptions), [displayOptions]);
 
+  // Select all only acts on the options currently displayed (e.g. after searching);
+  // deduplicated so repeated option values cannot be added to the selection twice
+  const selectableValues = [
+    ...new Set(
+      displayOptions
+        .map((option) => option.value)
+        .filter((value): value is T => value !== undefined),
+    ),
+  ];
+  const areAllSelected =
+    selectableValues.length > 0 && selectableValues.every((value) => preValues.includes(value));
+  const isAnySelected = selectableValues.some((value) => preValues.includes(value));
+
   const isSubmitDisabled =
     preValues.every((preValue) => values.includes(preValue)) &&
     values.every((value) => preValues.includes(value));
@@ -125,6 +151,16 @@ export function MultiSelectField<T extends SelectOptionValue>({
       setPreValues(next);
       onPendingChange?.(next);
     }
+  };
+
+  const handleToggleSelectAll = (e: React.MouseEvent<HTMLDivElement, MouseEvent>) => {
+    e.preventDefault();
+
+    const next = areAllSelected
+      ? preValues.filter((value) => !selectableValues.includes(value))
+      : [...preValues, ...selectableValues.filter((value) => !preValues.includes(value))];
+    setPreValues(next);
+    onPendingChange?.(next);
   };
 
   const handleSearch = (newSearch: string) => {
@@ -207,6 +243,24 @@ export function MultiSelectField<T extends SelectOptionValue>({
             />
           )}
           <SelectFieldContentList disabled={isLoading}>
+            {showSelectAll && selectableValues.length > 0 && (
+              <>
+                <SelectListOption
+                  label={areAllSelected ? deselectAllLabel : selectAllLabel}
+                  onClick={handleToggleSelectAll}
+                  startIcon={
+                    areAllSelected ? (
+                      <IconSquareCheckFilled />
+                    ) : isAnySelected ? (
+                      <IconSquareMinus />
+                    ) : (
+                      <IconSquare />
+                    )
+                  }
+                />
+                <Divider className={styles.selectAllDivider} />
+              </>
+            )}
             {groupedOptions
               ? Object.entries(groupedOptions).map(([category, categoryOptions]) => (
                   <Fragment key={category}>

--- a/src/components/editors/selects/MultiSelectField/MultiSelectField.tsx
+++ b/src/components/editors/selects/MultiSelectField/MultiSelectField.tsx
@@ -133,6 +133,13 @@ export function MultiSelectField<T extends SelectOptionValue>({
     selectableValues.length > 0 && selectableValues.every((value) => preValues.includes(value));
   const isAnySelected = selectableValues.some((value) => preValues.includes(value));
 
+  let selectAllIcon = <IconSquare />;
+  if (areAllSelected) {
+    selectAllIcon = <IconSquareCheckFilled />;
+  } else if (isAnySelected) {
+    selectAllIcon = <IconSquareMinus />;
+  }
+
   const isSubmitDisabled =
     preValues.every((preValue) => values.includes(preValue)) &&
     values.every((value) => preValues.includes(value));
@@ -248,15 +255,7 @@ export function MultiSelectField<T extends SelectOptionValue>({
                 <SelectListOption
                   label={areAllSelected ? deselectAllLabel : selectAllLabel}
                   onClick={handleToggleSelectAll}
-                  startIcon={
-                    areAllSelected ? (
-                      <IconSquareCheckFilled />
-                    ) : isAnySelected ? (
-                      <IconSquareMinus />
-                    ) : (
-                      <IconSquare />
-                    )
-                  }
+                  startIcon={selectAllIcon}
                 />
                 <Divider className={styles.selectAllDivider} />
               </>

--- a/src/components/editors/selects/selects.module.css
+++ b/src/components/editors/selects/selects.module.css
@@ -2,6 +2,11 @@
   margin-bottom: var(--em-selectfield-content-gap, 0.5rem);
 }
 
+.selectAllDivider {
+  flex-shrink: 0;
+  margin-bottom: var(--em-selectfield-content-gap, 0.5rem);
+}
+
 .submitButton {
   margin-top: var(--em-selectfield-content-gap, 0.5rem);
   justify-content: center;


### PR DESCRIPTION
## Summary

Adds an opt-in **select all / deselect all** row to `MultiSelectField`:

- New props: `showSelectAll` (off by default), `selectAllLabel` / `deselectAllLabel` for translated labels.
- The row toggles the **currently displayed** options: with a search active it only (de)selects matching values and preserves selections outside the filter.
- Checkbox icon reflects state, including an indeterminate icon on partial selection; the label flips between select all / deselect all.
- Separated from the options by the shared `Divider` (themeable via `--em-divider-*`), spaced with `--em-selectfield-content-gap`.
- Repeated option values are deduplicated so select all cannot add the same value twice.
- Changeset: minor.

Consumed by the companion remarkable-pro PR (merge this one first, publish, then the pro PR).

## Test plan

- 12 new unit tests covering rendering, custom labels, select/deselect, search scoping, duplicate values, and `onPendingChange` (45 total pass).
- New `WithSelectAll` Storybook story.
- Verified in-browser: menu stays open on toggle, label/icon states, divider rendering, Apply emits unique values.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added an optional “Select all”/“Deselect all” control to multi-select fields.
  - Supports custom labels and selection scoped to currently displayed or searched options.
  - Correctly handles partial selections, duplicate values, and empty option lists.

- **Bug Fixes**
  - Improved selection state updates when selecting or deselecting multiple values.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->