### PR TITLE
RUI-000: sync DateRangePickerField grid when value changes externally

### DIFF
--- a/.changeset/curly-otters-sing.md
+++ b/.changeset/curly-otters-sing.md
@@ -1,0 +1,5 @@
+---
+'@embeddable.com/remarkable-ui': patch
+---
+
+Fix DateRangePickerField not syncing its calendar grid when `value` changes externally while the dropdown is closed

--- a/src/components/editors/dates/DateRangePickerField/DateRangePickerField.test.tsx
+++ b/src/components/editors/dates/DateRangePickerField/DateRangePickerField.test.tsx
@@ -196,6 +196,21 @@ describe('DateRangePickerField', () => {
       expect(screen.getByRole('button', { name: 'Apply' })).toBeDisabled();
     });
 
+    it('syncs the grid when value changes externally while closed', async () => {
+      const user = userEvent.setup();
+      const { rerender } = render(<DateRangePickerField value={JUNE_RANGE} onChange={vi.fn()} />);
+
+      const JULY_RANGE = {
+        from: new Date('2024-07-01T00:00:00.000Z'),
+        to: new Date('2024-07-31T23:59:59.999Z'),
+      };
+      rerender(<DateRangePickerField value={JULY_RANGE} onChange={vi.fn()} />);
+
+      await openDropdown(user);
+
+      expect(screen.getByRole('button', { name: 'Apply' })).toBeDisabled();
+    });
+
     it('calls onChange with undefined when the clear button is clicked', async () => {
       const user = userEvent.setup();
       const handleChange = vi.fn();

--- a/src/components/editors/dates/DateRangePickerField/DateRangePickerField.test.tsx
+++ b/src/components/editors/dates/DateRangePickerField/DateRangePickerField.test.tsx
@@ -208,6 +208,8 @@ describe('DateRangePickerField', () => {
 
       await openDropdown(user);
 
+      const startCell = screen.getByRole('button', { name: /july 5/i }).closest('[aria-selected]');
+      expect(startCell).toHaveAttribute('aria-selected', 'true');
       expect(screen.getByRole('button', { name: 'Apply' })).toBeDisabled();
     });
 

--- a/src/components/editors/dates/DateRangePickerField/DateRangePickerField.tsx
+++ b/src/components/editors/dates/DateRangePickerField/DateRangePickerField.tsx
@@ -1,4 +1,4 @@
-import { FC, useState } from 'react';
+import { FC, useEffect, useState } from 'react';
 import { FieldHeader, FieldHeaderProps } from '../../../shared/Field/FieldHeader';
 import { Dropdown } from '../../../shared/Dropdown/Dropdown';
 import { SelectFieldTrigger } from '../../selects/shared/SelectFieldTrigger/SelectFieldTrigger';
@@ -59,6 +59,10 @@ export const DateRangePickerField: FC<DateRangePickerFieldProps> = ({
 }) => {
   const [isOpen, setIsOpen] = useState(false);
   const [currentDateRange, setCurrentDateRange] = useState<DateRange | undefined>(value);
+
+  useEffect(() => {
+    setCurrentDateRange(value);
+  }, [value]);
 
   const valueLabel = getDateRangePickerLabel(value, displayValue);
   const hasError = error || !!errorMessage;


### PR DESCRIPTION
## Summary
- `DateRangePickerField` only used `value` to seed `currentDateRange`'s initial state, so pushing a new `value` prop while the dropdown was closed never updated the visible grid — the trigger label was fine but reopening showed the stale calendar.
- Added a `useEffect` to keep `currentDateRange` synced to `value` whenever it changes.

Found while building on `remarkable-pro`: `DateRangePickerCustomPro` had to work around this with a `key` remount hack.

## Test plan
- [x] `DateRangePickerField.test.tsx` — added a regression test asserting the grid reflects a new `value` after an external rerender while closed
- [x] `vitest run` — all 21 tests pass

## Evidence


https://github.com/user-attachments/assets/2f4e3822-63e4-4dfa-96af-146dba0b435f



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved date-range picker synchronization when values change externally while the calendar is closed.
  * The calendar now displays the latest date range when reopened, with the Apply button correctly disabled when no changes are pending.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->